### PR TITLE
Removes backward-incompatible syntax for 2.1.0-preview2

### DIFF
--- a/lib/memory_profiler/results.rb
+++ b/lib/memory_profiler/results.rb
@@ -67,7 +67,7 @@ module MemoryProfiler
 
     def string_report(data, top)
       data
-        .keep_if{|id,stat| stat.class_name == "String"f}
+        .keep_if{|id,stat| stat.class_name == "String"}
         .map{|id,stat| [ObjectSpace._id2ref(id), "#{stat.file}:#{stat.line}"]}
         .group_by{|string, location| string}
         .sort_by{|string, list| -list.count}


### PR DESCRIPTION
- https://bugs.ruby-lang.org/issues/9042
