### PR TITLE
Fix "comparison of Array with Array failed (ArgumentError)"

### DIFF
--- a/lib/memory_profiler/top_n.rb
+++ b/lib/memory_profiler/top_n.rb
@@ -14,6 +14,7 @@ module MemoryProfiler
         end
 
       sorted.compact!
+      sorted.reject! { |row| row[0].nil? }
       sorted.sort!
 
       found = []


### PR DESCRIPTION
Trying to profile something complicated threw "comparison of Array with Array failed (ArgumentError)". The fix in this PR appears to work around, though I admit to not understanding why element 0 of a row might be nil?