### PR TITLE
Add allow_files option to #report method

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,31 @@ end
 report.pretty_print
 ```
 
+You can use `allow_files` option for displaying only lines which contain string or array with strings:
+
+```
+pry> require 'memory_profiler'
+pry> MemoryProfiler.report(allow_files: 'rubygems'){ require 'mime-types'  }.pretty_print
+Total allocated 82375
+Total retained 22618
+
+allocated memory by gem
+-----------------------------------
+rubygems x 305879
+
+allocated memory by file
+-----------------------------------
+/home/sam/.rbenv/versions/2.1.0-github/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb x 285433
+/home/sam/.rbenv/versions/2.1.0-github/lib/ruby/2.1.0/rubygems/basic_specification.rb x 18597
+/home/sam/.rbenv/versions/2.1.0-github/lib/ruby/2.1.0/rubygems.rb x 2218
+/home/sam/.rbenv/versions/2.1.0-github/lib/ruby/2.1.0/rubygems/specification.rb x 1169
+/home/sam/.rbenv/versions/2.1.0-github/lib/ruby/2.1.0/rubygems/defaults.rb x 520
+/home/sam/.rbenv/versions/2.1.0-github/lib/ruby/2.1.0/rubygems/core_ext/kernel_gem.rb x 80
+/home/sam/.rbenv/versions/2.1.0-github/lib/ruby/2.1.0/rubygems/version.rb x 80
+
+. . .
+```
+
 Example Session:
 
 You can easily use memory_profiler to profile require impact of a gem, for example:

--- a/lib/memory_profiler/reporter.rb
+++ b/lib/memory_profiler/reporter.rb
@@ -14,6 +14,7 @@ module MemoryProfiler
       @top          = opts[:top] || 50
       @trace        = opts[:trace]
       @ignore_files = opts[:ignore_files]
+      @allow_files = Array(opts[:allow_files])
     end
 
     # Helper for generating new reporter and running against block
@@ -73,6 +74,11 @@ module MemoryProfiler
       @ignore_files && @ignore_files =~ file
     end
 
+    def allow_file?(file)
+      return true if @allow_files.empty?
+      !/#{@allow_files.join('|')}/.match(file).to_s.empty?
+    end
+
     # Iterates through objects in memory of a given generation.
     # Stores results along with meta data of objects collected.
     def object_list(generation, rvalue_size)
@@ -93,7 +99,7 @@ module MemoryProfiler
 
       objs.each do |obj|
         file = ObjectSpace.allocation_sourcefile(obj)
-        next if ignore_file?(file)
+        next if !allow_file?(file) || ignore_file?(file)
 
         line       = ObjectSpace.allocation_sourceline(obj)
         class_path = ObjectSpace.allocation_class_path(obj)

--- a/lib/memory_profiler/results.rb
+++ b/lib/memory_profiler/results.rb
@@ -73,7 +73,7 @@ module MemoryProfiler
           .sort_by { |string, list| -list.count }
           .first(top)
           .map { |string, list| [string, list.group_by { |str, location| location }
-                                             .map { |location, locations| [location, locations.count] }] }
+          .map { |location, locations| [location, locations.count] }] }
     end
 
     def pretty_print(io = STDOUT, options = {})
@@ -87,8 +87,8 @@ module MemoryProfiler
           .product(["memory", "objects"])
           .product(["gem", "file", "location"])
           .each do |(type, metric), name|
-        dump "#{type} #{metric} by #{name}", self.send("#{type}_#{metric}_by_#{name}"), io
-      end
+            dump "#{type} #{metric} by #{name}", self.send("#{type}_#{metric}_by_#{name}"), io
+          end
 
       io.puts
       dump_strings(io, "Allocated", strings_allocated)


### PR DESCRIPTION
Sometimes I need to profile some code only for one gem or file which contain specific strings. That is why i think that this option will be helpful not only for me. 