### PR TITLE
Type error on rescue with string argument

### DIFF
--- a/lib/memory_profiler/results.rb
+++ b/lib/memory_profiler/results.rb
@@ -68,7 +68,7 @@ module MemoryProfiler
     def string_report(data, top)
       data
           .reject { |id, stat| stat.class_name != "String" }
-          .map { |id, stat| [begin; ObjectSpace._id2ref(id); rescue "__UNKNOWN__"; end, "#{stat.file}:#{stat.line}"] }
+          .map { |id, stat| [begin; ObjectSpace._id2ref(id); rescue; "__UNKNOWN__"; end, "#{stat.file}:#{stat.line}"] }
           .group_by { |string, location| string }
           .sort_by { |string, list| -list.count }
           .first(top)


### PR DESCRIPTION
Using rescue with a string as an argument results in an `TypeError: class or module required for rescue clause`.

I'd guess that the `__UNKNOWN__` string is instead meant as a fallback for the `_id2ref` call instead as some kind of exception type.
