### PR TITLE
Report on total memory size as well as counts

### DIFF
--- a/lib/memory_profiler/reporter.rb
+++ b/lib/memory_profiler/reporter.rb
@@ -109,7 +109,8 @@ module MemoryProfiler
         begin
           object_id = obj.__id__
 
-          memsize = ObjectSpace.memsize_of(obj) + rvalue_size
+          memsize = ObjectSpace.memsize_of(obj)
+          memsize += rvalue_size if RUBY_VERSION < '2.2'.freeze
           # compensate for API bug
           memsize = rvalue_size if memsize > 100_000_000_000
           results[object_id] = Stat.new(class_name, file, line, class_path, method_id, memsize)

--- a/lib/memory_profiler/results.rb
+++ b/lib/memory_profiler/results.rb
@@ -38,6 +38,7 @@ module MemoryProfiler
 
     attr_accessor :strings_retained, :strings_allocated
     attr_accessor :total_retained, :total_allocated
+    attr_accessor :total_retained_memsize, :total_allocated_memsize
 
     def self.from_raw(allocated, retained, top)
       self.new.register_results(allocated, retained, top)
@@ -62,7 +63,9 @@ module MemoryProfiler
       self.strings_retained = string_report(retained, top)
 
       self.total_allocated = allocated.count
+      self.total_allocated_memsize = allocated.values.sum(&:memsize)
       self.total_retained = retained.count
+      self.total_retained_memsize = retained.values.sum(&:memsize)
 
       self
     end
@@ -86,8 +89,9 @@ module MemoryProfiler
       color_output = options.fetch(:color_output) { io.respond_to?(:isatty) && io.isatty }
       @colorize = color_output ? Polychrome.new : Monochrome.new
 
-      io.puts "Total allocated #{total_allocated}"
-      io.puts "Total retained #{total_retained}"
+      io.puts "Total allocated #{total_allocated_memsize} (#{total_allocated})"
+      io.puts "Total retained #{total_retained_memsize} (#{total_retained})"
+
       io.puts
       ["allocated", "retained"]
           .product(["memory", "objects"])

--- a/lib/memory_profiler/results.rb
+++ b/lib/memory_profiler/results.rb
@@ -63,9 +63,9 @@ module MemoryProfiler
       self.strings_retained = string_report(retained, top)
 
       self.total_allocated = allocated.count
-      self.total_allocated_memsize = allocated.values.map(&:memsize).inject(:+)
+      self.total_allocated_memsize = allocated.values.map(&:memsize).inject(:+) || 0
       self.total_retained = retained.count
-      self.total_retained_memsize = retained.values.map(&:memsize).inject(:+)
+      self.total_retained_memsize = retained.values.map(&:memsize).inject(:+) || 0
 
       self
     end
@@ -89,8 +89,8 @@ module MemoryProfiler
       color_output = options.fetch(:color_output) { io.respond_to?(:isatty) && io.isatty }
       @colorize = color_output ? Polychrome.new : Monochrome.new
 
-      io.puts "Total allocated #{total_allocated_memsize} (#{total_allocated})"
-      io.puts "Total retained #{total_retained_memsize} (#{total_retained})"
+      io.puts "Total allocated: #{total_allocated_memsize} bytes (#{total_allocated} objects)"
+      io.puts "Total retained:  #{total_retained_memsize} bytes (#{total_retained} objects)"
 
       io.puts
       ["allocated", "retained"]

--- a/lib/memory_profiler/results.rb
+++ b/lib/memory_profiler/results.rb
@@ -63,9 +63,9 @@ module MemoryProfiler
       self.strings_retained = string_report(retained, top)
 
       self.total_allocated = allocated.count
-      self.total_allocated_memsize = allocated.values.sum(&:memsize)
+      self.total_allocated_memsize = allocated.values.map(&:memsize).inject(:+)
       self.total_retained = retained.count
-      self.total_retained_memsize = retained.values.sum(&:memsize)
+      self.total_retained_memsize = retained.values.map(&:memsize).inject(:+)
 
       self
     end


### PR DESCRIPTION
This adds the total memsize for allocated and retained objects. I formatted the output to show the memsize first and the count second in parenthesis. Let me know if there is a better way to be more clear what is what.
```
Total allocated 41181580 (221034)
Total retained 10410968 (13135)
```
