### PR TITLE
Performance tunings for speed

### DIFF
--- a/lib/memory_profiler/helpers.rb
+++ b/lib/memory_profiler/helpers.rb
@@ -1,15 +1,21 @@
 module MemoryProfiler
   module Helpers
     def self.guess_gem(path)
-      if /(\/gems\/.*)*\/gems\/(?<gem>[^\/]+)/ =~ path
-        gem
-      elsif /\/rubygems\// =~ path
-        "rubygems"
-      elsif /(?<app>[^\/]+\/(bin|app|lib))/ =~ path
-        app
-      else
-        "other"
-      end
+      @@gem_guess_cache ||= Hash.new
+      @@gem_guess_cache[path] ||=
+        if /(\/gems\/.*)*\/gems\/(?<gem>[^\/]+)/ =~ path
+          gem
+        elsif /\/rubygems\// =~ path
+          "rubygems"
+        elsif /(?<app>[^\/]+\/(bin|app|lib))/ =~ path
+          app
+        else
+          "other"
+        end
+    end
+
+    def self.reset_gem_guess_cache
+      @@gem_guess_cache = Hash.new
     end
 
     # helper to work around GC.start not freeing everything

--- a/lib/memory_profiler/helpers.rb
+++ b/lib/memory_profiler/helpers.rb
@@ -1,21 +1,22 @@
 module MemoryProfiler
-  module Helpers
-    def self.guess_gem(path)
-      @@gem_guess_cache ||= Hash.new
-      @@gem_guess_cache[path] ||=
+  class Helpers
+
+    def initialize
+      @gem_guess_cache = Hash.new
+    end
+
+    def guess_gem(path)
+      @gem_guess_cache[path] ||=
         if /(\/gems\/.*)*\/gems\/(?<gem>[^\/]+)/ =~ path
           gem
         elsif /\/rubygems\// =~ path
-          "rubygems"
+          "rubygems".freeze
         elsif /(?<app>[^\/]+\/(bin|app|lib))/ =~ path
           app
         else
-          "other"
+          "other".freeze
         end
     end
 
-    def self.reset_gem_guess_cache
-      @@gem_guess_cache = Hash.new
-    end
   end
 end

--- a/lib/memory_profiler/helpers.rb
+++ b/lib/memory_profiler/helpers.rb
@@ -4,6 +4,7 @@ module MemoryProfiler
     def initialize
       @gem_guess_cache = Hash.new
       @location_cache = Hash.new({})
+      @class_name_cache = Hash.new.compare_by_identity
     end
 
     def guess_gem(path)
@@ -21,6 +22,10 @@ module MemoryProfiler
 
     def lookup_location(file, line)
       @location_cache[file][line] ||= "#{file}:#{line}"
+    end
+
+    def lookup_class_name(klass)
+      @class_name_cache[klass] ||= klass.name
     end
 
   end

--- a/lib/memory_profiler/helpers.rb
+++ b/lib/memory_profiler/helpers.rb
@@ -21,7 +21,7 @@ module MemoryProfiler
     # helper to work around GC.start not freeing everything
     def self.full_gc
       # TODO: discuss with @tmm1 and @ko1 if the while loop is needed
-      GC.start(full_mark: true) while new_count = decreased_count(new_count)
+      GC.start while new_count = decreased_count(new_count)
     end
 
     def self.decreased_count(old)

--- a/lib/memory_profiler/helpers.rb
+++ b/lib/memory_profiler/helpers.rb
@@ -17,27 +17,5 @@ module MemoryProfiler
     def self.reset_gem_guess_cache
       @@gem_guess_cache = Hash.new
     end
-
-    # helper to work around GC.start not freeing everything
-    def self.full_gc
-      # TODO: discuss with @tmm1 and @ko1 if the while loop is needed
-      GC.start while new_count = decreased_count(new_count)
-    end
-
-    def self.decreased_count(old)
-      count = count_objects
-      if !old || count < old
-        count
-      else
-        nil
-      end
-    end
-
-    def self.count_objects
-      i = 0
-      ObjectSpace.each_object do |obj|
-        i += 1
-      end
-    end
   end
 end

--- a/lib/memory_profiler/helpers.rb
+++ b/lib/memory_profiler/helpers.rb
@@ -3,7 +3,7 @@ module MemoryProfiler
 
     def initialize
       @gem_guess_cache = Hash.new
-      @location_cache = Hash.new({})
+      @location_cache = Hash.new({}.compare_by_identity)
       @class_name_cache = Hash.new.compare_by_identity
     end
 

--- a/lib/memory_profiler/helpers.rb
+++ b/lib/memory_profiler/helpers.rb
@@ -3,6 +3,7 @@ module MemoryProfiler
 
     def initialize
       @gem_guess_cache = Hash.new
+      @location_cache = Hash.new({})
     end
 
     def guess_gem(path)
@@ -16,6 +17,10 @@ module MemoryProfiler
         else
           "other".freeze
         end
+    end
+
+    def lookup_location(file, line)
+      @location_cache[file][line] ||= "#{file}:#{line}"
     end
 
   end

--- a/lib/memory_profiler/reporter.rb
+++ b/lib/memory_profiler/reporter.rb
@@ -36,11 +36,11 @@ module MemoryProfiler
       Helpers.full_gc
       GC.disable
 
+      generation = GC.count
       ObjectSpace.trace_object_allocations do
-        generation = GC.count
         block.call
-        allocated = object_list(generation, rvalue_size)
       end
+      allocated = object_list(generation, rvalue_size)
 
       results = Results.new
       results.strings_allocated = results.string_report(allocated, top)
@@ -70,7 +70,6 @@ module MemoryProfiler
     end
 
     def ignore_file?(file)
-      return true if file == __FILE__
       @ignore_files && @ignore_files =~ file
     end
 

--- a/lib/memory_profiler/reporter.rb
+++ b/lib/memory_profiler/reporter.rb
@@ -95,10 +95,11 @@ module MemoryProfiler
       helper = Helpers.new
 
       objs.map! do |obj|
-        file = ObjectSpace.allocation_sourcefile(obj)
+        file = ObjectSpace.allocation_sourcefile(obj) || "(no name)".freeze
         next if !allow_file?(file) || ignore_file?(file)
 
         line       = ObjectSpace.allocation_sourceline(obj)
+        location   = helper.lookup_location(file, line)
         klass      = obj.class
         class_name = klass.name
         gem        = helper.guess_gem(file)
@@ -110,7 +111,7 @@ module MemoryProfiler
           memsize = ObjectSpace.memsize_of(obj) + rvalue_size_adjustment
           # compensate for API bug
           memsize = rvalue_size if memsize > 100_000_000_000
-          [object_id, MemoryProfiler::Stat.new(class_name, gem, file, line, memsize, string)]
+          [object_id, MemoryProfiler::Stat.new(class_name, gem, file, location, memsize, string)]
         rescue
           # __id__ is not defined, give up
         end

--- a/lib/memory_profiler/reporter.rb
+++ b/lib/memory_profiler/reporter.rb
@@ -108,12 +108,14 @@ module MemoryProfiler
           memsize = ObjectSpace.memsize_of(obj) + rvalue_size_adjustment
           # compensate for API bug
           memsize = rvalue_size if memsize > 100_000_000_000
-          [object_id, Stat.new(klass, file, line, class_path, memsize, string)]
+          [object_id, MemoryProfiler::Stat.new(klass, file, line, class_path, memsize, string)]
         rescue
           # __id__ is not defined, give up
         end
       end
       objs.compact!
+
+      Helpers.reset_gem_guess_cache
 
       StatHash[objs]
     end

--- a/lib/memory_profiler/reporter.rb
+++ b/lib/memory_profiler/reporter.rb
@@ -51,6 +51,8 @@ module MemoryProfiler
 
       retained = StatHash.new
       ObjectSpace.each_object do |obj|
+        retained_generation = ObjectSpace.allocation_generation(obj)
+        next unless retained_generation && generation == retained_generation
         begin
           found = allocated[obj.__id__]
           retained[obj.__id__] = found if found
@@ -60,6 +62,7 @@ module MemoryProfiler
           # but it is quite rare
         end
       end
+      ObjectSpace.trace_object_allocations_clear
 
       results.register_results(allocated, retained, top)
       results

--- a/lib/memory_profiler/reporter.rb
+++ b/lib/memory_profiler/reporter.rb
@@ -99,7 +99,6 @@ module MemoryProfiler
 
         line       = ObjectSpace.allocation_sourceline(obj)
         class_path = ObjectSpace.allocation_class_path(obj)
-        method_id  = ObjectSpace.allocation_method_id(obj)
 
         class_name = obj.class.name rescue "BasicObject".freeze
         begin
@@ -108,7 +107,7 @@ module MemoryProfiler
           memsize = ObjectSpace.memsize_of(obj) + rvalue_size_adjustment
           # compensate for API bug
           memsize = rvalue_size if memsize > 100_000_000_000
-          [object_id, Stat.new(class_name, file, line, class_path, method_id, memsize)]
+          [object_id, Stat.new(class_name, file, line, class_path, memsize)]
         rescue
           # __id__ is not defined, give up
         end

--- a/lib/memory_profiler/reporter.rb
+++ b/lib/memory_profiler/reporter.rb
@@ -93,7 +93,7 @@ module MemoryProfiler
         line       = ObjectSpace.allocation_sourceline(obj)
         location   = helper.lookup_location(file, line)
         klass      = obj.class
-        class_name = klass.name
+        class_name = helper.lookup_class_name(klass)
         gem        = helper.guess_gem(file)
         string     = obj.dup if klass == String
 

--- a/lib/memory_profiler/reporter.rb
+++ b/lib/memory_profiler/reporter.rb
@@ -99,15 +99,16 @@ module MemoryProfiler
 
         line       = ObjectSpace.allocation_sourceline(obj)
         class_path = ObjectSpace.allocation_class_path(obj)
+        klass      = obj.class
+        string     = obj.dup if klass == String
 
-        class_name = obj.class.name rescue "BasicObject".freeze
         begin
           object_id = obj.__id__
 
           memsize = ObjectSpace.memsize_of(obj) + rvalue_size_adjustment
           # compensate for API bug
           memsize = rvalue_size if memsize > 100_000_000_000
-          [object_id, Stat.new(class_name, file, line, class_path, memsize)]
+          [object_id, Stat.new(klass, file, line, class_path, memsize, string)]
         rescue
           # __id__ is not defined, give up
         end

--- a/lib/memory_profiler/reporter.rb
+++ b/lib/memory_profiler/reporter.rb
@@ -48,8 +48,7 @@ module MemoryProfiler
 
       retained = StatHash.new
       ObjectSpace.each_object do |obj|
-        retained_generation = ObjectSpace.allocation_generation(obj)
-        next unless retained_generation && generation == retained_generation
+        next unless ObjectSpace.allocation_generation(obj) == generation
         begin
           found = allocated[obj.__id__]
           retained[obj.__id__] = found if found
@@ -81,7 +80,7 @@ module MemoryProfiler
       objs = []
 
       ObjectSpace.each_object do |obj|
-        next unless generation == ObjectSpace.allocation_generation(obj)
+        next unless ObjectSpace.allocation_generation(obj) == generation
         begin
           if !trace || trace.include?(obj.class)
             objs << obj

--- a/lib/memory_profiler/results.rb
+++ b/lib/memory_profiler/results.rb
@@ -27,12 +27,12 @@ module MemoryProfiler
 
       @@lookups.each do |name, stat_attribute|
 
-        memsize_results, count_results = allocated.max_n(top, stat_attribute)
+        memsize_results, count_results = allocated.top_n(top, stat_attribute)
 
         self.send("allocated_memory_by_#{name}=", memsize_results)
         self.send("allocated_objects_by_#{name}=", count_results)
 
-        memsize_results, count_results = retained.max_n(top, stat_attribute)
+        memsize_results, count_results = retained.top_n(top, stat_attribute)
 
         self.send("retained_memory_by_#{name}=", memsize_results)
         self.send("retained_objects_by_#{name}=", count_results)

--- a/lib/memory_profiler/results.rb
+++ b/lib/memory_profiler/results.rb
@@ -67,6 +67,8 @@ module MemoryProfiler
       self.total_retained = retained.count
       self.total_retained_memsize = retained.values.map(&:memsize).inject(:+) || 0
 
+      Helpers.reset_gem_guess_cache
+
       self
     end
 

--- a/lib/memory_profiler/results.rb
+++ b/lib/memory_profiler/results.rb
@@ -60,6 +60,7 @@ module MemoryProfiler
         self.send "#{name}=", result
       end
 
+      self.strings_allocated = string_report(allocated, top)
       self.strings_retained = string_report(retained, top)
 
       self.total_allocated = allocated.count

--- a/lib/memory_profiler/results.rb
+++ b/lib/memory_profiler/results.rb
@@ -52,9 +52,9 @@ module MemoryProfiler
 
         result =
             if name.start_with?('allocated'.freeze)
-              allocated.top_n(top, &mapped)
+              allocated.max_n(top, &mapped)
             else
-              retained.top_n(top, &mapped)
+              retained.max_n(top, &mapped)
             end
 
         self.send "#{name}=", result

--- a/lib/memory_profiler/results.rb
+++ b/lib/memory_profiler/results.rb
@@ -73,14 +73,15 @@ module MemoryProfiler
     end
 
     def string_report(data, top)
-      data
-          .reject { |id, stat| stat.class_name != "String".freeze }
-          .map { |id, stat| [begin; ObjectSpace._id2ref(id); rescue; "__UNKNOWN__".freeze; end, stat.location] }
-          .group_by { |string, location| string }
-          .sort_by { |string, list| -list.count }
-          .first(top)
-          .map { |string, list| [string, list.group_by { |str, location| location }
-          .map { |location, locations| [location, locations.count] }] }
+      data.values
+          .keep_if { |stat| stat.klass == String }
+          .map! { |stat| [stat.string_value, stat.location] }
+          .group_by { |string, _location| string }
+          .max_by(top) {|_string, list| list.count }
+          .map { |string, list| [string, list.group_by { |_string, location| location }
+                                             .map { |location, locations| [location, locations.count] }
+                                ]
+          }
     end
 
     def pretty_print(io = STDOUT, **options)

--- a/lib/memory_profiler/results.rb
+++ b/lib/memory_profiler/results.rb
@@ -42,9 +42,9 @@ module MemoryProfiler
       self.strings_allocated = string_report(allocated, top)
       self.strings_retained = string_report(retained, top)
 
-      self.total_allocated = allocated.count
+      self.total_allocated = allocated.size
       self.total_allocated_memsize = allocated.values.map!(&:memsize).inject(0, :+)
-      self.total_retained = retained.count
+      self.total_retained = retained.size
       self.total_retained_memsize = retained.values.map!(&:memsize).inject(0, :+)
 
       self
@@ -52,13 +52,13 @@ module MemoryProfiler
 
     def string_report(data, top)
       data.values
-          .keep_if { |stat| stat.class_name == 'String'.freeze }
+          .keep_if { |stat| stat.string_value }
           .map! { |stat| [stat.string_value, stat.location] }
           .group_by { |string, _location| string }
-          .sort_by {|_string, list| -list.count }
+          .sort_by {|_string, list| -list.size }
           .first(top)
           .map { |string, list| [string, list.group_by { |_string, location| location }
-                                             .map { |location, locations| [location, locations.count] }
+                                             .map { |location, locations| [location, locations.size] }
                                 ]
           }
     end

--- a/lib/memory_profiler/results.rb
+++ b/lib/memory_profiler/results.rb
@@ -52,7 +52,7 @@ module MemoryProfiler
 
     def string_report(data, top)
       data.values
-          .keep_if { |stat| stat.klass == String }
+          .keep_if { |stat| stat.class_name == 'String'.freeze }
           .map! { |stat| [stat.string_value, stat.location] }
           .group_by { |string, _location| string }
           .sort_by {|_string, list| -list.count }

--- a/lib/memory_profiler/results.rb
+++ b/lib/memory_profiler/results.rb
@@ -55,7 +55,8 @@ module MemoryProfiler
           .keep_if { |stat| stat.klass == String }
           .map! { |stat| [stat.string_value, stat.location] }
           .group_by { |string, _location| string }
-          .max_by(top) {|_string, list| list.count }
+          .sort_by {|_string, list| -list.count }
+          .first(top)
           .map { |string, list| [string, list.group_by { |_string, location| location }
                                              .map { |location, locations| [location, locations.count] }
                                 ]

--- a/lib/memory_profiler/results.rb
+++ b/lib/memory_profiler/results.rb
@@ -20,21 +20,13 @@ module MemoryProfiler
       end
     end
 
-    register_type :gem, lambda { |stat|
-                        Helpers.guess_gem(stat.file)
-                      }
+    register_type :gem, lambda { |stat| stat.gem }
 
-    register_type :file, lambda { |stat|
-                         stat.file || "(no name)"
-                       }
+    register_type :file, lambda { |stat| stat.file }
 
-    register_type :location, lambda { |stat|
-                             stat.location
-                           }
+    register_type :location, lambda { |stat| stat.location }
 
-    register_type :class, lambda { |stat|
-                             stat.class_name
-                           }
+    register_type :class, lambda { |stat| stat.class_name }
 
     attr_accessor :strings_retained, :strings_allocated
     attr_accessor :total_retained, :total_allocated

--- a/lib/memory_profiler/results.rb
+++ b/lib/memory_profiler/results.rb
@@ -21,7 +21,7 @@ module MemoryProfiler
     end
 
     register_type :gem, lambda { |stat|
-                        Helpers.guess_gem("#{stat.file}")
+                        Helpers.guess_gem(stat.file)
                       }
 
     register_type :file, lambda { |stat|
@@ -29,11 +29,11 @@ module MemoryProfiler
                        }
 
     register_type :location, lambda { |stat|
-                             "#{stat.file}:#{stat.line}"
+                             stat.location
                            }
 
     register_type :class, lambda { |stat|
-                             "#{stat.class_name}"
+                             stat.class_name
                            }
 
     attr_accessor :strings_retained, :strings_allocated
@@ -75,7 +75,7 @@ module MemoryProfiler
     def string_report(data, top)
       data
           .reject { |id, stat| stat.class_name != "String" }
-          .map { |id, stat| [begin; ObjectSpace._id2ref(id); rescue; "__UNKNOWN__"; end, "#{stat.file}:#{stat.line}"] }
+          .map { |id, stat| [begin; ObjectSpace._id2ref(id); rescue; "__UNKNOWN__"; end, stat.location] }
           .group_by { |string, location| string }
           .sort_by { |string, list| -list.count }
           .first(top)

--- a/lib/memory_profiler/stat.rb
+++ b/lib/memory_profiler/stat.rb
@@ -1,14 +1,13 @@
 module MemoryProfiler
   class Stat
 
-    attr_reader :class_name, :file, :line, :class_path, :method_id, :memsize
+    attr_reader :class_name, :file, :line, :class_path, :memsize
 
-    def initialize(class_name, file, line, class_path, method_id, memsize)
+    def initialize(class_name, file, line, class_path, memsize)
       @class_name = class_name
       @file = file
       @line = line
       @class_path = class_path
-      @method_id = method_id
       @memsize = memsize
     end
 

--- a/lib/memory_profiler/stat.rb
+++ b/lib/memory_profiler/stat.rb
@@ -1,19 +1,18 @@
 module MemoryProfiler
   class Stat
 
-    attr_reader :klass, :file, :line, :class_path, :memsize, :string_value, :gem, :location, :class_name
+    attr_reader :class_name, :gem, :file, :line, :location, :memsize, :string_value
 
-    def initialize(klass, file, line, class_path, memsize, string_value)
-      @klass = klass
+    def initialize(class_name, gem, file, line, memsize, string_value)
+      @class_name = class_name
+      @gem = gem
+
       @file = file || "(no name)".freeze
       @line = line
-      @class_path = class_path
+      @location = "#{file}:#{line}"
+
       @memsize = memsize
       @string_value = string_value
-
-      @gem = Helpers.guess_gem(file)
-      @location = "#{file}:#{line}"
-      @class_name = klass.name rescue "BasicObject".freeze
     end
 
   end

--- a/lib/memory_profiler/stat.rb
+++ b/lib/memory_profiler/stat.rb
@@ -1,3 +1,24 @@
 module MemoryProfiler
-  Stat = Struct.new(:class_name, :file, :line, :class_path, :method_id, :memsize)
+  class Stat
+
+    attr_reader :class_name, :file, :line, :class_path, :method_id, :memsize
+
+    def initialize(class_name, file, line, class_path, method_id, memsize)
+      @class_name = class_name
+      @file = file
+      @line = line
+      @class_path = class_path
+      @method_id = method_id
+      @memsize = memsize
+    end
+
+    def gem
+      @gem ||= Helpers.guess_gem(file)
+    end
+
+    def location
+      @location ||= "#{file}:#{line}"
+    end
+
+  end
 end

--- a/lib/memory_profiler/stat.rb
+++ b/lib/memory_profiler/stat.rb
@@ -1,14 +1,15 @@
 module MemoryProfiler
   class Stat
 
-    attr_reader :class_name, :file, :line, :class_path, :memsize
+    attr_reader :klass, :file, :line, :class_path, :memsize, :string_value
 
-    def initialize(class_name, file, line, class_path, memsize)
-      @class_name = class_name
+    def initialize(klass, file, line, class_path, memsize, string_value)
+      @klass = klass
       @file = file
       @line = line
       @class_path = class_path
       @memsize = memsize
+      @string_value = string_value
     end
 
     def gem
@@ -19,5 +20,8 @@ module MemoryProfiler
       @location ||= "#{file}:#{line}"
     end
 
+    def class_name
+      @class_name ||= klass.name rescue "BasicObject".freeze
+    end
   end
 end

--- a/lib/memory_profiler/stat.rb
+++ b/lib/memory_profiler/stat.rb
@@ -1,27 +1,20 @@
 module MemoryProfiler
   class Stat
 
-    attr_reader :klass, :file, :line, :class_path, :memsize, :string_value
+    attr_reader :klass, :file, :line, :class_path, :memsize, :string_value, :gem, :location, :class_name
 
     def initialize(klass, file, line, class_path, memsize, string_value)
       @klass = klass
-      @file = file
+      @file = file || "(no name)".freeze
       @line = line
       @class_path = class_path
       @memsize = memsize
       @string_value = string_value
+
+      @gem = Helpers.guess_gem(file)
+      @location = "#{file}:#{line}"
+      @class_name = klass.name rescue "BasicObject".freeze
     end
 
-    def gem
-      @gem ||= Helpers.guess_gem(file)
-    end
-
-    def location
-      @location ||= "#{file}:#{line}"
-    end
-
-    def class_name
-      @class_name ||= klass.name rescue "BasicObject".freeze
-    end
   end
 end

--- a/lib/memory_profiler/stat.rb
+++ b/lib/memory_profiler/stat.rb
@@ -1,15 +1,14 @@
 module MemoryProfiler
   class Stat
 
-    attr_reader :class_name, :gem, :file, :line, :location, :memsize, :string_value
+    attr_reader :class_name, :gem, :file, :location, :memsize, :string_value
 
-    def initialize(class_name, gem, file, line, memsize, string_value)
+    def initialize(class_name, gem, file, location, memsize, string_value)
       @class_name = class_name
       @gem = gem
 
-      @file = file || "(no name)".freeze
-      @line = line
-      @location = "#{file}:#{line}"
+      @file = file
+      @location = location
 
       @memsize = memsize
       @string_value = string_value

--- a/lib/memory_profiler/top_n.rb
+++ b/lib/memory_profiler/top_n.rb
@@ -50,5 +50,18 @@ module MemoryProfiler
         .sort!{|x,y| x[:count] <=> y[:count] }
         .reverse
     end
+
+    # Fast approach for determining the top_n entries in a list.
+    def max_n(max = 10, &block)
+
+      sorted = self.map(&block)
+
+      found = sorted.group_by { |item, _weight| item }.
+        map { |key, values| [key, values.reduce(0) { |sum, item| _key, weight = item ; sum += (weight || 1) }] }.
+        max_by(max) { |data| data[1] }.
+        map! { |metric, total| { data: metric, count: total } }.
+        sort!{ |x, y| y[:count] <=> x[:count] }
+
+    end
   end
 end

--- a/lib/memory_profiler/top_n.rb
+++ b/lib/memory_profiler/top_n.rb
@@ -1,59 +1,8 @@
 module MemoryProfiler
   module TopN
-    # Efficient mechanism for finding top_n entries in a list
-    # optional block can specify custom element and weight
-    def top_n(max = 10)
-
-      sorted =
-        if block_given?
-          self.map { |row|
-            yield(row)
-          }
-        else
-          self.dup
-        end
-
-      sorted.compact!
-      sorted.sort!
-
-      found = []
-
-      last = sorted[0]
-      count = 0
-      lowest_count = 0
-
-      sorted << nil
-
-      sorted.each do |row|
-
-        current_item, current_count = row
-
-        unless current_item == last
-          if count > lowest_count
-            found << {data: last, count: count}
-          end
-
-          if found.length > max
-            found.sort!{|x,y| x[:count] <=> y[:count] }
-            found.delete_at(0)
-            lowest_count = found[0][:count]
-          end
-
-          count = 0
-          last = current_item
-        end
-
-        count += (current_count || 1) unless row.nil?
-      end
-
-      found
-        .sort!{|x,y| x[:count] <=> y[:count] }
-        .reverse
-    end
-
-    # Fast approach for determining the top_n entries in a list of Stat objects.
+    # Fast approach for determining the top_n entries in a Hash of Stat objects.
     # Returns results for both memory (memsize summed) and objects allocated (count) as a tuple.
-    def max_n(max, metric)
+    def top_n(max, metric)
 
       stats_by_metric = self.values.map! { |stat| [stat.send(metric), stat.memsize] }
 

--- a/lib/memory_profiler/top_n.rb
+++ b/lib/memory_profiler/top_n.rb
@@ -60,10 +60,10 @@ module MemoryProfiler
       stat_totals = stats_by_metric.group_by { |metric_value, _memsize| metric_value }.
           map { |key, values| [key, values.reduce(0) { |sum, item| _key, memsize = item ; sum + memsize }, values.count] }
 
-      stats_by_memsize = stat_totals.max_by(max) { |data| data[1] }.
-          map! { |metric, total| { data: metric, count: total } }
-      stats_by_count   = stat_totals.max_by(max) { |data| data[2] }.
-          map! { |metric, total| { data: metric, count: total } }
+      stats_by_memsize = stat_totals.sort_by { |data| -data[1] }.first(max).
+          map! { |metric, memsize, _count| { data: metric, count: memsize } }
+      stats_by_count   = stat_totals.sort_by { |data| -data[2] }.first(max).
+          map! { |metric, _memsize, count| { data: metric, count: count } }
 
       [stats_by_memsize, stats_by_count]
 

--- a/lib/memory_profiler/top_n.rb
+++ b/lib/memory_profiler/top_n.rb
@@ -58,11 +58,11 @@ module MemoryProfiler
       stats_by_metric = self.values.map! { |stat| [stat.send(metric), stat.memsize] }
 
       stat_totals = stats_by_metric.group_by { |metric_value, _memsize| metric_value }.
-          map { |key, values| [key, values.reduce(0) { |sum, item| _key, memsize = item ; sum + memsize }, values.count] }
+          map { |key, values| [key, values.reduce(0) { |sum, item| _key, memsize = item ; sum + memsize }, values.size] }
 
-      stats_by_memsize = stat_totals.sort_by { |data| -data[1] }.first(max).
+      stats_by_memsize = stat_totals.sort_by! { |data| -data[1] }.first(max).
           map! { |metric, memsize, _count| { data: metric, count: memsize } }
-      stats_by_count   = stat_totals.sort_by { |data| -data[2] }.first(max).
+      stats_by_count   = stat_totals.sort_by! { |data| -data[2] }.first(max).
           map! { |metric, _memsize, count| { data: metric, count: count } }
 
       [stats_by_memsize, stats_by_count]

--- a/test/test_helpers.rb
+++ b/test/test_helpers.rb
@@ -4,7 +4,8 @@ module MemoryProfiler
 
   class TestHelpers < Minitest::Test
     def assert_gem_parse(expected, path)
-      assert_equal(expected, Helpers.guess_gem(path))
+      helper = Helpers.new
+      assert_equal(expected, helper.guess_gem(path))
     end
 
     def test_rubygems_parse

--- a/test/test_top_n.rb
+++ b/test/test_top_n.rb
@@ -1,39 +1,53 @@
 require_relative 'test_helper'
 
-class ArrayWithTopN < Array
+class HashWithTopN < Hash
   include MemoryProfiler::TopN
 end
 
 class TestTopN < Minitest::Test
 
-  def tn(*vals)
-    ArrayWithTopN.new.concat(vals)
+  TestItem = Struct.new(:metric1, :metric2, :memsize)
+
+  def sample_data
+    HashWithTopN.new.merge!(
+        {
+            1 => TestItem.new('class1', 'gem1', 100),
+            2 => TestItem.new('class1', 'gem2', 100),
+            3 => TestItem.new('class1', 'gem3', 100),
+            4 => TestItem.new('class2', 'gem1', 100),
+            5 => TestItem.new('class2', 'gem1', 100),
+            6 => TestItem.new('class2', 'gem1', 100),
+            7 => TestItem.new('class3', 'gem2', 1000)
+        }
+    )
   end
 
-  def test_top_n
-    data = tn( 7,1,2,2,3,3,99,3 )
-    results = data.top_n(2)
+  def test_top_n_small_n
+    data = sample_data
+    metric1_results = data.top_n(2, :metric1)
+    metric2_results = data.top_n(2, :metric2)
 
-    assert_equal([{data: 3, count: 3}, {data: 2, count: 2}], results)
+    assert_equal([[{:data=>"class3", :count=>1000}, {:data=>"class2", :count=>300}],
+                  [{:data=>"class1", :count=>3}, {:data=>"class2", :count=>3}]],
+                 metric1_results)
+
+    assert_equal([[{:data=>"gem2", :count=>1100}, {:data=>"gem1", :count=>400}],
+                  [{:data=>"gem1", :count=>4}, {:data=>"gem2", :count=>2}]],
+                 metric2_results)
   end
 
-  def test_top_n_with_block
-    data = tn( 0,3,6,1,4,2 )
+  def test_top_n_large_n
+    data = sample_data
+    metric1_results = data.top_n(50, :metric1)
+    metric2_results = data.top_n(50, :metric2)
 
-    results = data.top_n(2) do |r|
-      r%3
-    end
+    assert_equal([[{:data=>"class3", :count=>1000}, {:data=>"class2", :count=>300}, {:data=>"class1", :count=>300}],
+                  [{:data=>"class1", :count=>3}, {:data=>"class2", :count=>3}, {:data=>"class3", :count=>1}]],
+                 metric1_results)
 
-    assert_equal([{data: 0, count: 3}, {data: 1, count: 2}], results)
-  end
-  def test_top_n_with_block_and_size
-    data = tn( [1,100], [1,10], [2,1], [2,1], [2,1],[3,100] )
-
-    results = data.top_n(2) do |r|
-      r
-    end
-
-    assert_equal([{data: 1, count: 110}, {data: 3, count: 100}], results)
+    assert_equal([[{:data=>"gem2", :count=>1100}, {:data=>"gem1", :count=>400}, {:data=>"gem3", :count=>100}],
+                  [{:data=>"gem1", :count=>4}, {:data=>"gem2", :count=>2}, {:data=>"gem3", :count=>1}]],
+                 metric2_results)
   end
 
 end


### PR DESCRIPTION
I'd noticed that MemoryProfiler has been taking a bit longer to run since Class reporting was added. Or more likely, all my programs all just use too much memory. :) I've taken a pass at several performance tunings to speed things up. This branch still needs some testing and a solid benchmark but I wanted to share it and see if you had any feedback.

On my sample program it is about 3-4x faster (~17 -> ~5 seconds for 200K objects, 18MB). The main improvements come from reducing the time the `ObjectSpace#trace_object_allocations` is in effect, caching the Gem lookups, and calculating the Top N for objects allocated and memory in one pass.

While I was working on this, I came across an issue where `object_id`s from `allocated` objects were getting reused after the GC and causing problems with the `retained` object stats. This might be the cause of #21 and #12.

Part of solving the re-used object_id issue was to go back to a simple `GC.start` rather than using the `Helper.full_gc` method. `full_gc` was allocating one Hash for the option params which reused a recycled object_id. That method could be re-enabled if needed, but I wasn't sure what the cause of GC.start not collecting all of the objects that method is meant to resolve.

I tried to make the commits atomic enough to be understandable individually or possibly to be merged individually. Let me know if you see anything that stands out as likely to cause a problem or headed in the wrong direction.

Thanks!