### PR TITLE
Change lookup_class_name method to always return string.

### DIFF
--- a/lib/memory_profiler/helpers.rb
+++ b/lib/memory_profiler/helpers.rb
@@ -25,7 +25,7 @@ module MemoryProfiler
     end
 
     def lookup_class_name(klass)
-      @class_name_cache[klass] ||= (klass.is_a?(Class) && klass.name) || '<<Unknown>>'
+      @class_name_cache[klass] ||= ((klass.is_a?(Class) && klass.name) || '<<Unknown>>').to_s
     end
 
   end

--- a/test/test_reporter.rb
+++ b/test/test_reporter.rb
@@ -15,6 +15,11 @@ class TestReporter < Minitest::Test
       'StringReportingClass'
     end
   end
+  class NonStringNamedClass
+    def self.name
+      :Symbol
+    end
+  end
 
   # Shared method that creates a Results with 1 retained object using options provided
   def create_report(options={})
@@ -156,6 +161,16 @@ class TestReporter < Minitest::Test
     io = StringIO.new
     results.pretty_print io, color_output: false
     assert(!io.string.include?("\033"), 'excludes color information')
+  end
+
+  def test_non_string_named_class
+    report = MemoryProfiler.report do
+      NonStringNamedClass.new
+      "test"
+    end
+
+    io = StringIO.new
+    report.pretty_print io
   end
 
 end


### PR DESCRIPTION
When profiling code with a class which redefines 'name' class method to return a
symbol instead of default name, top_n method fails with error:
"... memory_profiler/top_n.rb:13:in `sort_by': comparison of Array with Array
failed (ArgumentError)".

So I changed lookup_class_name to call to_s on klass.name.