### PR TITLE
Implement Reporter#start and Reporter#stop for alternative profiling workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,22 @@ end
 report.pretty_print
 ```
 
+Or, you can use the `.start`/`.stop` API as well:
+
+```ruby
+require 'memory_profiler'
+
+MemoryProfiler.start
+
+# run your code
+
+report = MemoryProfiler.stop
+report.pretty_print
+```
+
+**NOTE:**  `.start`/`.stop` can only be run once per report, and `.stop` will
+be the only time you can retrieve the report using this API.
+
 ## Options
 
 The report method can take a few options:

--- a/lib/memory_profiler.rb
+++ b/lib/memory_profiler.rb
@@ -13,6 +13,19 @@ module MemoryProfiler
     opts[:top] ||= 50
     Reporter.report(opts,&block)
   end
+
+  def self.start(opts={})
+    unless Reporter.current_reporter
+      Reporter.current_reporter = Reporter.new(opts)
+      Reporter.current_reporter.start
+    end
+  end
+
+  def self.stop
+    Reporter.current_reporter.stop if Reporter.current_reporter
+  ensure
+    Reporter.current_reporter = nil
+  end
 end
 
 

--- a/lib/memory_profiler.rb
+++ b/lib/memory_profiler.rb
@@ -10,7 +10,6 @@ require "memory_profiler/reporter"
 
 module MemoryProfiler
   def self.report(opts={},&block)
-    opts[:top] ||= 50
     Reporter.report(opts,&block)
   end
 

--- a/lib/memory_profiler/reporter.rb
+++ b/lib/memory_profiler/reporter.rb
@@ -7,6 +7,10 @@ module MemoryProfiler
   #     5.times { "foo" }
   #   end
   class Reporter
+    class << self
+      attr_accessor :current_reporter
+    end
+
     attr_reader :top, :trace, :generation, :report_results
 
     def initialize(opts = {})

--- a/lib/memory_profiler/reporter.rb
+++ b/lib/memory_profiler/reporter.rb
@@ -62,7 +62,6 @@ module MemoryProfiler
       start
       block.call
       stop
-      report_results
     end
 
     private

--- a/lib/memory_profiler/reporter.rb
+++ b/lib/memory_profiler/reporter.rb
@@ -7,7 +7,7 @@ module MemoryProfiler
   #     5.times { "foo" }
   #   end
   class Reporter
-    attr_reader :top, :trace, :generation
+    attr_reader :top, :trace, :generation, :report_results
 
     def initialize(opts = {})
       @top          = opts[:top] || 50
@@ -27,16 +27,16 @@ module MemoryProfiler
       self.new(opts).run(&block)
     end
 
-    # Collects object allocation and memory of ruby code inside of passed block.
-    def run(&block)
-
+    def start
       GC.start
       GC.disable
 
       @generation = GC.count
-      ObjectSpace.trace_object_allocations do
-        block.call
-      end
+      ObjectSpace.trace_object_allocations_start
+    end
+
+    def stop
+      ObjectSpace.trace_object_allocations_stop
       allocated = object_list(generation)
       retained = StatHash.new.compare_by_identity
 
@@ -53,9 +53,16 @@ module MemoryProfiler
       end
       ObjectSpace.trace_object_allocations_clear
 
-      results = Results.new
-      results.register_results(allocated, retained, top)
-      results
+      @report_results = Results.new
+      @report_results.register_results(allocated, retained, top)
+    end
+
+    # Collects object allocation and memory of ruby code inside of passed block.
+    def run(&block)
+      start
+      block.call
+      stop
+      report_results
     end
 
     private

--- a/lib/memory_profiler/reporter.rb
+++ b/lib/memory_profiler/reporter.rb
@@ -7,7 +7,7 @@ module MemoryProfiler
   #     5.times { "foo" }
   #   end
   class Reporter
-    attr_reader :top, :trace
+    attr_reader :top, :trace, :generation
 
     def initialize(opts = {})
       @top          = opts[:top] || 50
@@ -33,7 +33,7 @@ module MemoryProfiler
       GC.start
       GC.disable
 
-      generation = GC.count
+      @generation = GC.count
       ObjectSpace.trace_object_allocations do
         block.call
       end

--- a/test/test_helpers.rb
+++ b/test/test_helpers.rb
@@ -1,5 +1,27 @@
 require_relative 'test_helper'
 
+class Foo; end
+class BasicObjectSubclass < BasicObject ; end
+class NilReportingClass
+  def class
+    # return nil when asked for the class
+    nil
+  end
+end
+class StringReportingClass
+  def class
+    # return a string when asked for the class
+    'StringReportingClass'
+  end
+end
+class NonStringNamedClass
+  # return a symbol when the class is asked for the name
+  def self.name
+    :Symbol
+  end
+end
+
+
 module MemoryProfiler
 
   class TestHelpers < Minitest::Test

--- a/test/test_reporter.rb
+++ b/test/test_reporter.rb
@@ -128,8 +128,20 @@ class TestReporter < Minitest::Test
     assert_equal(0, results.total_retained)
   end
 
+  def test_class_tracing_with_array_and_start_stop
+    results = create_start_stop_report(:trace => [Foo])
+    assert_equal(1, results.total_allocated)
+    assert_equal(0, results.total_retained)
+  end
+
   def test_class_tracing_with_value
     results = create_report(:trace => Foo)
+    assert_equal(1, results.total_allocated)
+    assert_equal(0, results.total_retained)
+  end
+
+  def test_class_tracing_with_value_and_start_stop
+    results = create_start_stop_report(:trace => Foo)
     assert_equal(1, results.total_allocated)
     assert_equal(0, results.total_retained)
   end
@@ -140,8 +152,20 @@ class TestReporter < Minitest::Test
     assert_equal(0, results.total_retained)
   end
 
+  def test_ignore_file_with_regex_and_start_stop
+    results = create_start_stop_report(:ignore_files => /test_reporter\.rb/)
+    assert_equal(3, results.total_allocated)
+    assert_equal(0, results.total_retained)
+  end
+
   def test_ignore_file_with_string
     results = create_report(:ignore_files => 'test_reporter.rb|another_file.rb')
+    assert_equal(3, results.total_allocated)
+    assert_equal(0, results.total_retained)
+  end
+
+  def test_ignore_file_with_string_and_start_stop
+    results = create_start_stop_report(:ignore_files => 'test_reporter.rb|another_file.rb')
     assert_equal(3, results.total_allocated)
     assert_equal(0, results.total_retained)
   end
@@ -152,8 +176,20 @@ class TestReporter < Minitest::Test
     assert_equal(1, results.total_retained)
   end
 
+  def test_allow_files_with_string_and_start_stop
+    results = create_start_stop_report(:allow_files => 'test_reporter')
+    assert_equal(13, results.total_allocated)
+    assert_equal(1, results.total_retained)
+  end
+
   def test_allow_files_with_array
     results = create_report(:allow_files => ['test_reporter', 'another_file'])
+    assert_equal(13, results.total_allocated)
+    assert_equal(1, results.total_retained)
+  end
+
+  def test_allow_files_with_array_and_start_stop
+    results = create_start_stop_report(:allow_files => ['test_reporter', 'another_file'])
     assert_equal(13, results.total_allocated)
     assert_equal(1, results.total_retained)
   end
@@ -165,8 +201,22 @@ class TestReporter < Minitest::Test
     assert(!io.string.include?("\033"), 'excludes color information')
   end
 
+  def test_no_color_output_and_start_stop
+    results = create_start_stop_report
+    io = StringIO.new
+    results.pretty_print io, color_output: false
+    assert(!io.string.include?("\033"), 'excludes color information')
+  end
+
   def test_color_output
     results = create_report
+    io = StringIO.new
+    results.pretty_print io, color_output: true
+    assert(io.string.include?("\033"), 'includes color information')
+  end
+
+  def test_color_output_with_start_stop
+    results = create_start_stop_report
     io = StringIO.new
     results.pretty_print io, color_output: true
     assert(io.string.include?("\033"), 'includes color information')
@@ -185,6 +235,13 @@ class TestReporter < Minitest::Test
     assert(io.string.include?("\033"), 'includes color information')
   end
 
+  def test_color_output_defaults_to_true_when_run_from_tty_with_start_stop
+    results = create_start_stop_report
+    io = StdoutMock.new
+    results.pretty_print io
+    assert(io.string.include?("\033"), 'includes color information')
+  end
+
   def test_mono_output_defaults_to_true_when_not_run_from_tty
     results = create_report
     io = StringIO.new
@@ -192,8 +249,27 @@ class TestReporter < Minitest::Test
     assert(!io.string.include?("\033"), 'excludes color information')
   end
 
+  def test_mono_output_defaults_to_true_when_not_run_from_tty_with_start_stop
+    results = create_start_stop_report
+    io = StringIO.new
+    results.pretty_print io
+    assert(!io.string.include?("\033"), 'excludes color information')
+  end
+
   def test_reports_can_be_reused_with_different_color_options
     results = create_report
+
+    io = StringIO.new
+    results.pretty_print io, color_output: true
+    assert(io.string.include?("\033"), 'includes color information')
+
+    io = StringIO.new
+    results.pretty_print io, color_output: false
+    assert(!io.string.include?("\033"), 'excludes color information')
+  end
+
+  def test_reports_can_be_reused_with_different_color_options_and_start_stop
+    results = create_start_stop_report
 
     io = StringIO.new
     results.pretty_print io, color_output: true

--- a/test/test_reporter.rb
+++ b/test/test_reporter.rb
@@ -2,27 +2,6 @@ require_relative 'test_helper'
 
 class TestReporter < Minitest::Test
 
-  class Foo; end
-  class BasicObjectSubclass < BasicObject ; end
-  class NilReportingClass
-    def class
-      # return nil when asked for the class
-      nil
-    end
-  end
-  class StringReportingClass
-    def class
-      # return a string when asked for the class
-      'StringReportingClass'
-    end
-  end
-  class NonStringNamedClass
-    # return a symbol when the class is asked for the name
-    def self.name
-      :Symbol
-    end
-  end
-
   # Reusable block for reporting.  Pass in an `Array` to retain objects after
   # allocation.
   def report_block(retained=[])
@@ -75,7 +54,7 @@ class TestReporter < Minitest::Test
     assert_equal(2, results.total_allocated)
     assert_equal(2, results.total_retained)
     assert_equal('BasicObject', results.allocated_objects_by_class[0][:data])
-    assert_equal('TestReporter::BasicObjectSubclass', results.allocated_objects_by_class[1][:data])
+    assert_equal('BasicObjectSubclass', results.allocated_objects_by_class[1][:data])
     assert_equal(2, results.retained_objects_by_location.length)
   end
 
@@ -100,7 +79,7 @@ class TestReporter < Minitest::Test
     end
     assert_equal(1, results.total_allocated)
     assert_equal(1, results.total_retained)
-    assert_equal('TestReporter::NilReportingClass', results.allocated_objects_by_class[0][:data])
+    assert_equal('NilReportingClass', results.allocated_objects_by_class[0][:data])
     assert_equal(1, results.retained_objects_by_location.length)
   end
 
@@ -111,7 +90,7 @@ class TestReporter < Minitest::Test
     end
     assert_equal(1, results.total_allocated)
     assert_equal(1, results.total_retained)
-    assert_equal('TestReporter::StringReportingClass', results.allocated_objects_by_class[0][:data])
+    assert_equal('StringReportingClass', results.allocated_objects_by_class[0][:data])
     assert_equal(1, results.retained_objects_by_location.length)
   end
 

--- a/test/test_reporter.rb
+++ b/test/test_reporter.rb
@@ -33,23 +33,6 @@ class TestReporter < Minitest::Test
     results
   end
 
-  def create_start_stop_report(options={})
-    retained = []
-    prof_block = report_block(retained)
-    reporter = MemoryProfiler::Reporter.new(options)
-    reporter.start
-    prof_block.call
-    reporter.stop
-  end
-
-  def create_convenient_start_stop_report(options={})
-    retained = []
-    prof_block = report_block(retained)
-    MemoryProfiler.start(options)
-    prof_block.call
-    MemoryProfiler.stop
-  end
-
   def test_basic_object
     retained = []
     results = create_report do
@@ -106,57 +89,8 @@ class TestReporter < Minitest::Test
     assert_equal(1, results.retained_objects_by_location.length)
   end
 
-  def test_counts_with_start_stop
-    results = create_start_stop_report
-    assert_equal(16, results.total_allocated)
-    assert_equal(1, results.total_retained)
-    assert_equal(1, results.retained_objects_by_location.length)
-  end
-
-  def test_counts_with_start_stop_on_module
-    results = create_convenient_start_stop_report
-    assert_equal(16, results.total_allocated)
-    assert_equal(1, results.total_retained)
-    assert_equal(1, results.retained_objects_by_location.length)
-  end
-
-  def test_module_stop_with_no_start
-    results = MemoryProfiler.stop
-    assert_nil(results)
-  end
-
-  def test_module_double_start
-    MemoryProfiler.start
-    reporter = MemoryProfiler::Reporter.current_reporter
-
-    # From create_convenient_start_stop_report
-    retained = []
-    prof_block = report_block(retained)
-    MemoryProfiler.start
-    same_reporter = MemoryProfiler::Reporter.current_reporter
-    prof_block.call
-    results = MemoryProfiler.stop
-    # end
-
-    assert_equal(reporter, same_reporter)
-    # Some extra here do to variables needed in the test above
-    assert_equal(20, results.total_allocated)
-  end
-
   def test_class_tracing_with_array
     results = create_report(:trace => [Foo])
-    assert_equal(1, results.total_allocated)
-    assert_equal(0, results.total_retained)
-  end
-
-  def test_class_tracing_with_array_and_start_stop
-    results = create_start_stop_report(:trace => [Foo])
-    assert_equal(1, results.total_allocated)
-    assert_equal(0, results.total_retained)
-  end
-
-  def test_class_tracing_with_array_and_start_stop_on_module
-    results = create_convenient_start_stop_report(:trace => [Foo])
     assert_equal(1, results.total_allocated)
     assert_equal(0, results.total_retained)
   end
@@ -167,32 +101,8 @@ class TestReporter < Minitest::Test
     assert_equal(0, results.total_retained)
   end
 
-  def test_class_tracing_with_value_and_start_stop
-    results = create_start_stop_report(:trace => Foo)
-    assert_equal(1, results.total_allocated)
-    assert_equal(0, results.total_retained)
-  end
-
-  def test_class_tracing_with_value_and_start_stop_on_module
-    results = create_convenient_start_stop_report(:trace => Foo)
-    assert_equal(1, results.total_allocated)
-    assert_equal(0, results.total_retained)
-  end
-
   def test_ignore_file_with_regex
     results = create_report(:ignore_files => /test_reporter\.rb/)
-    assert_equal(3, results.total_allocated)
-    assert_equal(0, results.total_retained)
-  end
-
-  def test_ignore_file_with_regex_and_start_stop
-    results = create_start_stop_report(:ignore_files => /test_reporter\.rb/)
-    assert_equal(3, results.total_allocated)
-    assert_equal(0, results.total_retained)
-  end
-
-  def test_ignore_file_with_regex_and_start_stop_on_module
-    results = create_convenient_start_stop_report(:ignore_files => /test_reporter\.rb/)
     assert_equal(3, results.total_allocated)
     assert_equal(0, results.total_retained)
   end
@@ -203,50 +113,14 @@ class TestReporter < Minitest::Test
     assert_equal(0, results.total_retained)
   end
 
-  def test_ignore_file_with_string_and_start_stop
-    results = create_start_stop_report(:ignore_files => 'test_reporter.rb|another_file.rb')
-    assert_equal(3, results.total_allocated)
-    assert_equal(0, results.total_retained)
-  end
-
-  def test_ignore_file_with_string_and_start_stop_on_module
-    results = create_convenient_start_stop_report(:ignore_files => 'test_reporter.rb|another_file.rb')
-    assert_equal(3, results.total_allocated)
-    assert_equal(0, results.total_retained)
-  end
-
   def test_allow_files_with_string
     results = create_report(:allow_files => 'test_reporter')
     assert_equal(13, results.total_allocated)
     assert_equal(1, results.total_retained)
   end
 
-  def test_allow_files_with_string_and_start_stop
-    results = create_start_stop_report(:allow_files => 'test_reporter')
-    assert_equal(13, results.total_allocated)
-    assert_equal(1, results.total_retained)
-  end
-
-  def test_allow_files_with_string_and_start_stop_on_module
-    results = create_convenient_start_stop_report(:allow_files => 'test_reporter')
-    assert_equal(13, results.total_allocated)
-    assert_equal(1, results.total_retained)
-  end
-
   def test_allow_files_with_array
     results = create_report(:allow_files => ['test_reporter', 'another_file'])
-    assert_equal(13, results.total_allocated)
-    assert_equal(1, results.total_retained)
-  end
-
-  def test_allow_files_with_array_and_start_stop
-    results = create_start_stop_report(:allow_files => ['test_reporter', 'another_file'])
-    assert_equal(13, results.total_allocated)
-    assert_equal(1, results.total_retained)
-  end
-
-  def test_allow_files_with_array_and_start_stop_on_module
-    results = create_convenient_start_stop_report(:allow_files => ['test_reporter', 'another_file'])
     assert_equal(13, results.total_allocated)
     assert_equal(1, results.total_retained)
   end
@@ -258,36 +132,8 @@ class TestReporter < Minitest::Test
     assert(!io.string.include?("\033"), 'excludes color information')
   end
 
-  def test_no_color_output_and_start_stop
-    results = create_start_stop_report
-    io = StringIO.new
-    results.pretty_print io, color_output: false
-    assert(!io.string.include?("\033"), 'excludes color information')
-  end
-
-  def test_no_color_output_and_start_stop_on_module
-    results = create_convenient_start_stop_report
-    io = StringIO.new
-    results.pretty_print io, color_output: false
-    assert(!io.string.include?("\033"), 'excludes color information')
-  end
-
   def test_color_output
     results = create_report
-    io = StringIO.new
-    results.pretty_print io, color_output: true
-    assert(io.string.include?("\033"), 'includes color information')
-  end
-
-  def test_color_output_with_start_stop
-    results = create_start_stop_report
-    io = StringIO.new
-    results.pretty_print io, color_output: true
-    assert(io.string.include?("\033"), 'includes color information')
-  end
-
-  def test_color_output_with_start_stop_on_module
-    results = create_convenient_start_stop_report
     io = StringIO.new
     results.pretty_print io, color_output: true
     assert(io.string.include?("\033"), 'includes color information')
@@ -306,20 +152,6 @@ class TestReporter < Minitest::Test
     assert(io.string.include?("\033"), 'includes color information')
   end
 
-  def test_color_output_defaults_to_true_when_run_from_tty_with_start_stop
-    results = create_start_stop_report
-    io = StdoutMock.new
-    results.pretty_print io
-    assert(io.string.include?("\033"), 'includes color information')
-  end
-
-  def test_color_output_defaults_to_true_when_run_from_tty_with_start_stop_on_module
-    results = create_convenient_start_stop_report
-    io = StdoutMock.new
-    results.pretty_print io
-    assert(io.string.include?("\033"), 'includes color information')
-  end
-
   def test_mono_output_defaults_to_true_when_not_run_from_tty
     results = create_report
     io = StringIO.new
@@ -327,46 +159,8 @@ class TestReporter < Minitest::Test
     assert(!io.string.include?("\033"), 'excludes color information')
   end
 
-  def test_mono_output_defaults_to_true_when_not_run_from_tty_with_start_stop
-    results = create_start_stop_report
-    io = StringIO.new
-    results.pretty_print io
-    assert(!io.string.include?("\033"), 'excludes color information')
-  end
-
-  def test_mono_output_defaults_to_true_when_not_run_from_tty_with_start_stop_on_module
-    results = create_convenient_start_stop_report
-    io = StringIO.new
-    results.pretty_print io
-    assert(!io.string.include?("\033"), 'excludes color information')
-  end
-
   def test_reports_can_be_reused_with_different_color_options
     results = create_report
-
-    io = StringIO.new
-    results.pretty_print io, color_output: true
-    assert(io.string.include?("\033"), 'includes color information')
-
-    io = StringIO.new
-    results.pretty_print io, color_output: false
-    assert(!io.string.include?("\033"), 'excludes color information')
-  end
-
-  def test_reports_can_be_reused_with_different_color_options_and_start_stop
-    results = create_start_stop_report
-
-    io = StringIO.new
-    results.pretty_print io, color_output: true
-    assert(io.string.include?("\033"), 'includes color information')
-
-    io = StringIO.new
-    results.pretty_print io, color_output: false
-    assert(!io.string.include?("\033"), 'excludes color information')
-  end
-
-  def test_reports_can_be_reused_with_different_color_options_and_start_stop_on_module
-    results = create_convenient_start_stop_report
 
     io = StringIO.new
     results.pretty_print io, color_output: true

--- a/test/test_reporter.rb
+++ b/test/test_reporter.rb
@@ -105,6 +105,20 @@ class TestReporter < Minitest::Test
     assert_equal(1, results.retained_objects_by_location.length)
   end
 
+  def test_counts_with_start_stop
+    retained = []
+    prof_block = report_block(retained)
+    reporter = MemoryProfiler::Reporter.new
+    reporter.start
+    prof_block.call
+    reporter.stop
+    results = reporter.report_results
+
+    assert_equal(16, results.total_allocated)
+    assert_equal(1, results.total_retained)
+    assert_equal(1, results.retained_objects_by_location.length)
+  end
+
   def test_class_tracing_with_array
     results = create_report(:trace => [Foo])
     assert_equal(1, results.total_allocated)

--- a/test/test_reporter.rb
+++ b/test/test_reporter.rb
@@ -49,6 +49,16 @@ class TestReporter < Minitest::Test
     results
   end
 
+  def create_start_stop_report(options={})
+    retained = []
+    prof_block = report_block(retained)
+    reporter = MemoryProfiler::Reporter.new(options)
+    reporter.start
+    prof_block.call
+    reporter.stop
+    reporter.report_results
+  end
+
   def test_basic_object
     retained = []
     results = MemoryProfiler::Reporter.report do
@@ -106,14 +116,7 @@ class TestReporter < Minitest::Test
   end
 
   def test_counts_with_start_stop
-    retained = []
-    prof_block = report_block(retained)
-    reporter = MemoryProfiler::Reporter.new
-    reporter.start
-    prof_block.call
-    reporter.stop
-    results = reporter.report_results
-
+    results = create_start_stop_report
     assert_equal(16, results.total_allocated)
     assert_equal(1, results.total_retained)
     assert_equal(1, results.retained_objects_by_location.length)

--- a/test/test_reporter.rb
+++ b/test/test_reporter.rb
@@ -56,7 +56,6 @@ class TestReporter < Minitest::Test
     reporter.start
     prof_block.call
     reporter.stop
-    reporter.report_results
   end
 
   def test_basic_object

--- a/test/test_reporter.rb
+++ b/test/test_reporter.rb
@@ -23,10 +23,10 @@ class TestReporter < Minitest::Test
     end
   end
 
-  # Shared method that creates a Results with 1 retained object using options provided
-  def create_report(options={})
-    retained = []
-    results = MemoryProfiler::Reporter.report(options) do
+  # Reusable block for reporting.  Pass in an `Array` to retain objects after
+  # allocation.
+  def report_block(retained=[])
+    lambda do
       # Create an object from a gem outside memory_profiler which allocates
       # its own objects internally
       minitest_report = MiniTest::Reporter.new
@@ -40,6 +40,12 @@ class TestReporter < Minitest::Test
       # Create one object defined by this file
       Foo.new
     end
+  end
+
+  # Shared method that creates a Results with 1 retained object using options provided
+  def create_report(options={})
+    retained = []
+    results = MemoryProfiler::Reporter.report options, &report_block(retained)
     results
   end
 

--- a/test/test_reporter_start_stop.rb
+++ b/test/test_reporter_start_stop.rb
@@ -1,0 +1,15 @@
+require_relative 'test_helper'
+require_relative 'test_reporter'
+
+class TestReporterStartStop < TestReporter
+
+  def create_report(options={}, &yield_for_report_block)
+    retained = []
+    prof_block = report_block(retained, &yield_for_report_block)
+    reporter = MemoryProfiler::Reporter.new(options)
+    reporter.start
+    prof_block.call
+    reporter.stop
+  end
+
+end

--- a/test/test_start_stop_api.rb
+++ b/test/test_start_stop_api.rb
@@ -1,0 +1,37 @@
+require_relative 'test_helper'
+require_relative 'test_reporter'
+
+class TestStartStopApi < TestReporter
+
+  def create_report(options={}, &yield_for_report_block)
+    retained = []
+    prof_block = report_block(retained, &yield_for_report_block)
+    MemoryProfiler.start(options)
+    prof_block.call
+    MemoryProfiler.stop
+  end
+
+  def test_module_stop_with_no_start
+    results = MemoryProfiler.stop
+    assert_nil(results)
+  end
+
+  def test_module_double_start
+    MemoryProfiler.start
+    reporter = MemoryProfiler::Reporter.current_reporter
+
+    # From create_report
+    retained = []
+    prof_block = report_block(retained)
+    MemoryProfiler.start
+    same_reporter = MemoryProfiler::Reporter.current_reporter
+    prof_block.call
+    results = MemoryProfiler.stop
+    # end
+
+    assert_equal(reporter, same_reporter)
+    # Some extra here do to variables needed in the test above
+    assert_equal(20, results.total_allocated)
+  end
+
+end


### PR DESCRIPTION
## Purpose

When the code block for profiling is not available to the caller of the Profiling code, this API interface allows for starting and stopping the profiler separately, similar to how [`stackprof`](https://github.com/tmm1/stackprof)'s API works.  This maintains the current API and functions equivalently, but allows for a more flexible API for the user.
## Notes
- 0606b17 is both implementing the `.start`/`.stop` methods, and refactoring `.run` to use them.  I originally split this work out into two commits (adding the two methods, then refactoring), but it leads to some extra commit noise and duplicate code that just didn't seem worth it.  If preferred, I can rebase to go back to that.
- I considered adding a `::start` and `::stop` method, but it would have required saving off a class instance variable (I think) to store the current instance of the `Reporter` that was run so `::stop` has something to run against.  I would have preferred to have this interface, but I chose not to include it currently since it would have added extra noise to the PR.  I can add to this one or open up a follow up PR to implement that.
- Possibly an `ensure` should now be included in the `.run` method since we are using the `.start`/`.stop` methods under the hood, and it seems like the source for `ObjectSpace.trace_object_allocations` includes one as well when in the source when calling out to `.trace_object_allocations_start` and `.trace_object_allocations_stop` itself.  I didn't implement this in this PR because:
  1.  My `C` chops are pretty, much non-existent and my understanding of the Ruby source codebase is just as bad
  2.  Still unsure if the `ensure` would be necessary
