### PR TITLE
Prevent conflicts with ruby PrettyPrint

### DIFF
--- a/lib/memory_profiler/results.rb
+++ b/lib/memory_profiler/results.rb
@@ -63,7 +63,11 @@ module MemoryProfiler
     # @param [Hash] options the options for output
     # @option opts [String] :to_file a path to your log file
     # @option opts [Boolean] :color_output a flag for whether to colorize output
-    def pretty_print(io = STDOUT, **options)
+    def pretty_print(io = $stdout, **options)
+      # Handle the special case that Ruby PrettyPrint expects `pretty_print`
+      # to be a customized pretty printing function for a class
+      return io.pp_object(self) if defined?(PP) && io.is_a?(PP)
+
       io = File.open(options[:to_file], "w") if options[:to_file]
 
       color_output = options.fetch(:color_output) { io.respond_to?(:isatty) && io.isatty }

--- a/test/test_results.rb
+++ b/test/test_results.rb
@@ -1,9 +1,18 @@
 require_relative 'test_helper'
 
 class TestResults < Minitest::Test
-  def test_pretty_print_works
-    io = StringIO.new
-    MemoryProfiler::Results.new.pretty_print io
+  def test_pretty_print_works_with_no_args
+    assert_output(/^Total allocated/, '') { MemoryProfiler::Results.new.pretty_print }
   end
 
+  def test_pretty_print_works_with_io_arg
+    io = StringIO.new
+    assert_silent { MemoryProfiler::Results.new.pretty_print(io) }
+    assert_match(/^Total allocated/, io.string)
+  end
+
+  def test_no_conflict_with_pretty_print
+    require 'pp'
+    assert_output(/#<MemoryProfiler::Results:\w*>/) { pp(MemoryProfiler::Results.new) }
+  end
 end


### PR DESCRIPTION
This handles the special case that Ruby PrettyPrint expects `pretty_print` to be a customized pretty printing function for a class. Nothing major but I've run into it and it bugged me. :)