### PR TITLE
Add back testing of public and private start/stop

### DIFF
--- a/test/test_reporter_private_start_stop.rb
+++ b/test/test_reporter_private_start_stop.rb
@@ -1,0 +1,23 @@
+require_relative 'test_reporter'
+
+class TestReporterPrivateStartStop < TestReporter
+  # This class extends TestReporter so it includes all of the tests from
+  # TestReporter plus any additional test_* cases below and it
+  # overrides create_report to use the start/stop methods
+
+  # This specifically tests the private API of the start and stop methods of
+  # the MemoryProfiler::Reporter class, and doesn't make use of the auto
+  # instantiation of the class which is provided in the public API.
+  #
+  # This is meant to be a "base case" for the public API:  if things are
+  # failing when testing the functionality of the public API, but not here,
+  # then there is something wrong when handling the `current_report` variable
+  # that needs to be addressed.
+  def create_report(options={}, &profiled_block)
+    profiled_block ||= -> { default_block }
+    reporter = MemoryProfiler::Reporter.new(options)
+    reporter.start
+    profiled_block.call
+    reporter.stop
+  end
+end

--- a/test/test_reporter_public_start_stop.rb
+++ b/test/test_reporter_public_start_stop.rb
@@ -1,16 +1,22 @@
 require_relative 'test_reporter'
 
-class TestReporterStartStop < TestReporter
+class TestReporterPublicStartStop < TestReporter
   # This class extends TestReporter so it includes all of the tests from
   # TestReporter plus any additional test_* cases below and it
   # overrides create_report to use the start/stop methods
 
+  # This specifically tests the public API of the start and stop methods of the
+  # MemoryProfiler module itself, and even does some extra tests exercising
+  # edge case handling of `current_reporter` which is done in those methods.
+  #
+  # When something fails here, and not in the private api tests, then there is
+  # something wrong specifically in the methods handling the `current_reporter`
+  # that needs to be fixed.
   def create_report(options={}, &profiled_block)
     profiled_block ||= -> { default_block }
-    reporter = MemoryProfiler::Reporter.new(options)
-    reporter.start
+    MemoryProfiler.start(options)
     profiled_block.call
-    reporter.stop
+    MemoryProfiler.stop
   end
 
   def test_module_stop_with_no_start


### PR DESCRIPTION
Also added comments describing the purpose of each test, which will help emphasize the difference between the two `create_report` methods in each of these classes.

These were removed in #43