### PR TITLE
Add "mem_lite" setting for generating reports

### DIFF
--- a/lib/memory_profiler/helpers.rb
+++ b/lib/memory_profiler/helpers.rb
@@ -1,5 +1,6 @@
 module MemoryProfiler
   class Helpers
+    STRING_MAX = 199 # 200 chars
 
     def initialize
       @gem_guess_cache = Hash.new
@@ -28,5 +29,8 @@ module MemoryProfiler
       @class_name_cache[klass] ||= ((klass.is_a?(Class) && klass.name) || '<<Unknown>>').to_s
     end
 
+    def string_summary(string)
+      string[0..STRING_MAX]
+    end
   end
 end

--- a/lib/memory_profiler/helpers.rb
+++ b/lib/memory_profiler/helpers.rb
@@ -1,3 +1,5 @@
+require 'digest'
+
 module MemoryProfiler
   class Helpers
     STRING_MAX = 199 # 200 chars
@@ -6,6 +8,7 @@ module MemoryProfiler
       @gem_guess_cache = Hash.new
       @location_cache = Hash.new { |h,k| h[k] = Hash.new.compare_by_identity }
       @class_name_cache = Hash.new.compare_by_identity
+      @digest_cache = Hash.new
     end
 
     def guess_gem(path)
@@ -31,6 +34,10 @@ module MemoryProfiler
 
     def string_summary(string)
       string[0..STRING_MAX]
+    end
+
+    def lookup_string_digest(string)
+      @digest_cache[string] ||= Digest::MD5.hexdigest(string)
     end
   end
 end

--- a/lib/memory_profiler/reporter.rb
+++ b/lib/memory_profiler/reporter.rb
@@ -105,7 +105,7 @@ module MemoryProfiler
           memsize = ObjectSpace.memsize_of(obj) + rvalue_size_adjustment
           # compensate for API bug
           memsize = rvalue_size if memsize > 100_000_000_000
-          result[obj.__id__] = MemoryProfiler::Stat.new(class_name, gem, file, location, memsize, string)
+          result[obj.__id__] = MemoryProfiler::Stat.new(class_name, gem, file, location, memsize, string, nil)
         rescue
           # give up if any any error occurs inspecting the object
         end

--- a/lib/memory_profiler/results.rb
+++ b/lib/memory_profiler/results.rb
@@ -99,7 +99,7 @@ module MemoryProfiler
       io.puts "#{title} String Report"
       io.puts @colorize.line("-----------------------------------")
       strings.each do |string, stats|
-        io.puts "#{stats.reduce(0) { |a, b| a + b[1] }.to_s.rjust(10)}  #{@colorize.string((string[0..200].inspect))}"
+        io.puts "#{stats.reduce(0) { |a, b| a + b[1] }.to_s.rjust(10)}  #{@colorize.string((string[0,200].inspect))}"
         stats.sort_by { |x, y| [-y, x] }.each do |location, count|
           io.puts "#{@colorize.path(count.to_s.rjust(10))}  #{location}"
         end

--- a/lib/memory_profiler/results.rb
+++ b/lib/memory_profiler/results.rb
@@ -49,11 +49,12 @@ module MemoryProfiler
     def string_report(data, top)
       data.values
           .keep_if { |stat| stat.string_value }
-          .map! { |stat| [stat.string_value, stat.location] }
-          .group_by { |string, _location| string }
-          .sort_by {|string, list| [-list.size, string] }
+          .map! { |stat| [stat.string_value, stat.md5, stat.location] }
+          .group_by { |string, md5, _location| md5 || string }
+          .sort_by {|str_md5, list| [-list.size, str_md5] }
           .first(top)
-          .map { |string, list| [string, list.group_by { |_string, location| location }
+          .map { |_s_md5, list| [list.first[0], list] } # use a string as a key again
+          .map { |string, list| [string, list.group_by { |_string, _md5, location| location }
                                              .map { |location, locations| [location, locations.size] }
                                 ]
           }

--- a/lib/memory_profiler/stat.rb
+++ b/lib/memory_profiler/stat.rb
@@ -1,9 +1,9 @@
 module MemoryProfiler
   class Stat
 
-    attr_reader :class_name, :gem, :file, :location, :memsize, :string_value
+    attr_reader :class_name, :gem, :file, :location, :memsize, :string_value, :md5
 
-    def initialize(class_name, gem, file, location, memsize, string_value)
+    def initialize(class_name, gem, file, location, memsize, string_value, md5)
       @class_name = class_name
       @gem = gem
 
@@ -12,6 +12,7 @@ module MemoryProfiler
 
       @memsize = memsize
       @string_value = string_value
+      @md5 = md5
     end
 
   end

--- a/test/test_helpers.rb
+++ b/test/test_helpers.rb
@@ -57,6 +57,16 @@ module MemoryProfiler
       helper = Helpers.new
       assert_equal("a" * 200, helper.string_summary("a" * 201))
     end
+
+    def test_lookup_string_digest
+      helper = Helpers.new
+      cache  = helper.instance_variable_get(:@digest_cache)
+      assert_equal(0, cache.count)
+      assert_equal("acbd18db4cc2f85cedef654fccc4a4d8", helper.lookup_string_digest("foo"))
+      assert_equal(1, cache.count)
+      helper.lookup_string_digest("foo")
+      assert_equal(1, cache.count)
+    end
   end
 
 end

--- a/test/test_helpers.rb
+++ b/test/test_helpers.rb
@@ -48,6 +48,15 @@ module MemoryProfiler
                         "/home/sam/Source/discourse/app/assets")
     end
 
+    def test_string_summary
+      helper = Helpers.new
+      assert_equal("expected", helper.string_summary("expected"))
+    end
+
+    def test_string_summary_with_long_string
+      helper = Helpers.new
+      assert_equal("a" * 200, helper.string_summary("a" * 201))
+    end
   end
 
 end

--- a/test/test_results.rb
+++ b/test/test_results.rb
@@ -15,4 +15,54 @@ class TestResults < Minitest::Test
     require 'pp'
     assert_output(/#<MemoryProfiler::Results:\w*>/) { pp(MemoryProfiler::Results.new) }
   end
+
+  def test_string_report_with_regular_string_data
+    allocated = MemoryProfiler::StatHash.new
+    retained  = string_data
+    results = MemoryProfiler::Results.new.register_results(allocated, retained, 50)
+
+    expected = <<-OUTPUT.gsub(/^ {6}/, "")
+      Retained String Report
+      -----------------------------------
+               3  "a"
+               2  #{file1.join(":")}
+               1  #{file2.join(":")}
+
+               2  "b"
+               1  #{file2.join(":")}
+               1  #{file1.join(":")}
+
+    OUTPUT
+
+    io = StringIO.new
+    assert_silent { results.pretty_print(io) }
+
+    # Rewind as much as is in the retained string report
+    io.seek(-expected.size, IO::SEEK_END)
+    assert_equal(expected, io.read)
+  end
+
+  private
+
+  def string_data(md5=false)
+    stat = MemoryProfiler::Stat
+    hash = MemoryProfiler::StatHash.new
+    gem  = "memory-profiler-#{MemoryProfiler::VERSION}"
+
+    hash[1] = stat.new("String", gem, file1[0], file1.join(":"), 10, "a", md5 && "1")
+    hash[2] = stat.new("String", gem, file1[0], file1.join(":"), 10, "a", md5 && "2")
+    hash[3] = stat.new("String", gem, file2[0], file2.join(":"), 10, "a", md5 && "1")
+    hash[4] = stat.new("String", gem, file1[0], file1.join(":"), 20, "b", md5 && "3")
+    hash[5] = stat.new("String", gem, file2[0], file2.join(":"), 20, "b", md5 && "3")
+
+    hash
+  end
+
+  def file1
+    @file1 ||= [ File.expand_path(__FILE__).to_s, 25 ]
+  end
+
+  def file2
+    @file_1 ||= MemoryProfiler::Results.method(:register_type).source_location
+  end
 end

--- a/test/test_results.rb
+++ b/test/test_results.rb
@@ -42,6 +42,35 @@ class TestResults < Minitest::Test
     assert_equal(expected, io.read)
   end
 
+  def test_string_report_with_md5_string_data
+    allocated = MemoryProfiler::StatHash.new
+    retained  = string_data(true)
+    results = MemoryProfiler::Results.new.register_results(allocated, retained, 50)
+
+    expected = <<-OUTPUT.gsub(/^ {6}/, "")
+      Retained String Report
+      -----------------------------------
+               2  "a"
+               1  #{file2.join(":")}
+               1  #{file1.join(":")}
+
+               2  "b"
+               1  #{file2.join(":")}
+               1  #{file1.join(":")}
+
+               1  "a"
+               1  #{file1.join(":")}
+
+    OUTPUT
+
+    io = StringIO.new
+    assert_silent { results.pretty_print(io) }
+
+    # Rewind as much as is in the retained string report
+    io.seek(-expected.size, IO::SEEK_END)
+    assert_equal(expected, io.read)
+  end
+
   private
 
   def string_data(md5=false)


### PR DESCRIPTION
Objective
---------
Allows the `MemoryProfiler::Reporter` to be run in less memory intensive way, at the cost of some speed in generating the report.  This is ideal in cases where there are a lot of objects that can be expanded into strings, and will be duplicated/create in the process generating the report while iterating over the `ObjectSpace`.

The `hexdigest`'ing is offset a bit by the cache (when in scenarios where that is helpful), but in the end, the bottle neck is the digests.

That all said, this is an opt-in setting, and the previous implementation is still unaffected and remains the default.


Case Study
----------
The specific example I built this from was about a 1GB process with large nested hash and a bunch of strings.  Most of the `MemoryProfiler::Reporter#stop` code worked fine, except for this line:

```ruby
string = '' << obj  if klass == String
```

Which was a clever way to `.dup` strings, but was causing a major explosion in memory (I was seeing the process explode to over 50Gigs before I had to give up and kill it).  

In testing this, I removed the above line, and the growth in memory was acceptable (there are some strings generated in this process, so it is to be expected), but it was more along the lines of another additional gig, and not 50X.

_**Update:**  A better explanation and reproducible case study can be found in this comment:_ 
 https://github.com/SamSaffron/memory_profiler/pull/48#issuecomment-329213258


I feel like something else is also at play here, but a gig of data is a lot to go through... Since this solution is opt-in, I figured I would toss this up as a PR and see what you all think.
