### PR TITLE
Handle exceptions raised during profiling

### DIFF
--- a/lib/memory_profiler/reporter.rb
+++ b/lib/memory_profiler/reporter.rb
@@ -64,8 +64,15 @@ module MemoryProfiler
     # Collects object allocation and memory of ruby code inside of passed block.
     def run(&block)
       start
-      block.call
-      stop
+      begin
+        block.call
+      rescue Exception
+        ObjectSpace.trace_object_allocations_stop
+        GC.enable
+        raise
+      else
+        stop
+      end
     end
 
     private

--- a/test/test_reporter.rb
+++ b/test/test_reporter.rb
@@ -179,4 +179,19 @@ class TestReporter < Minitest::Test
     assert_equal(2, results.retained_objects_by_location.length)
   end
 
+  def test_exception_handling
+    results = nil
+    assert_raises Exception do
+      results = create_report do
+        @retained << "hello"
+        raise Exception, "Raising exception"
+      end
+    end
+    assert_nil(results)
+    refute(GC.enable, "Re-enabling GC should return false because it is already enabled")
+
+    # Verify that memory_profiler is not reporting on itself following the exception
+    results = create_report(allow_files: 'lib/memory_profiler')
+    assert_equal(0, results.total_allocated)
+  end
 end

--- a/test/test_reporter_private_start_stop.rb
+++ b/test/test_reporter_private_start_stop.rb
@@ -17,7 +17,11 @@ class TestReporterPrivateStartStop < TestReporter
     profiled_block ||= -> { default_block }
     reporter = MemoryProfiler::Reporter.new(options)
     reporter.start
-    profiled_block.call
+    profiled_block.call rescue nil
     reporter.stop
+  end
+
+  def test_exception_handling
+    # This overrides and skips exception handling from the base TestReporter
   end
 end

--- a/test/test_reporter_public_start_stop.rb
+++ b/test/test_reporter_public_start_stop.rb
@@ -15,7 +15,7 @@ class TestReporterPublicStartStop < TestReporter
   def create_report(options={}, &profiled_block)
     profiled_block ||= -> { default_block }
     MemoryProfiler.start(options)
-    profiled_block.call
+    profiled_block.call rescue nil
     MemoryProfiler.stop
   end
 
@@ -38,4 +38,7 @@ class TestReporterPublicStartStop < TestReporter
     assert_equal(17, results.total_allocated)
   end
 
+  def test_exception_handling
+    # This overrides and skips exception handling from the base TestReporter
+  end
 end


### PR DESCRIPTION
This PR addresses a possible cause of #49 when the code block being profiled raises an exception. In that case, `ObjectSpace.trace_object_allocations_start` is called but `ObjectSpace.trace_object_allocations_stop` isn't. Also, with an exception, we were staying in a state of having GC disabled.

BTW, it is still possible for MemoryProfiler to report on itself if something else calls `ObjectSpace.trace_object_allocations_start` before doing profiling. We rely on allocation tracing being fully stopped before doing the analysis.