### PR TITLE
Reduce internal memory usage while processing string allocations

### DIFF
--- a/lib/memory_profiler/helpers.rb
+++ b/lib/memory_profiler/helpers.rb
@@ -5,6 +5,7 @@ module MemoryProfiler
       @gem_guess_cache = Hash.new
       @location_cache = Hash.new { |h,k| h[k] = Hash.new.compare_by_identity }
       @class_name_cache = Hash.new.compare_by_identity
+      @string_cache = Hash.new
     end
 
     def guess_gem(path)
@@ -28,5 +29,8 @@ module MemoryProfiler
       @class_name_cache[klass] ||= ((klass.is_a?(Class) && klass.name) || '<<Unknown>>').to_s
     end
 
+    def lookup_string(obj)
+      @string_cache[obj] ||= String.new << obj
+    end
   end
 end

--- a/lib/memory_profiler/reporter.rb
+++ b/lib/memory_profiler/reporter.rb
@@ -100,7 +100,7 @@ module MemoryProfiler
           class_name = helper.lookup_class_name(klass)
           gem        = helper.guess_gem(file)
 
-          string     = '' << obj  if klass == String
+          string     = klass == String ? helper.lookup_string(obj) : nil
 
           memsize = ObjectSpace.memsize_of(obj) + rvalue_size_adjustment
           # compensate for API bug


### PR DESCRIPTION
This PR implements the simple string cache discussed in #48 to reduce the number of String objects created internally to track allocated strings. Duplicated strings will now only allocate one shared String that is used in the Stats.