### PR TITLE
Reduce memory needed for string allocation tracing

### DIFF
--- a/lib/memory_profiler/helpers.rb
+++ b/lib/memory_profiler/helpers.rb
@@ -30,7 +30,10 @@ module MemoryProfiler
     end
 
     def lookup_string(obj)
-      @string_cache[obj] ||= String.new << obj
+      # This string is shortened to 200 characters which is what the string report shows
+      # The string report can still list unique strings longer than 200 characters
+      #   separately because the object_id of the shortened string will be different
+      @string_cache[obj] ||= obj[0,200]
     end
   end
 end

--- a/lib/memory_profiler/results.rb
+++ b/lib/memory_profiler/results.rb
@@ -49,15 +49,14 @@ module MemoryProfiler
     def string_report(data, top)
       data.values.
         keep_if { |stat| stat.string_value }.
-        # Hash by string and object_id. Strings >200 chars have been shortened
-        # and will have different object_ids
-        group_by { |stat| "#{stat.string_value} - #{stat.string_value.object_id}" }.
-        sort_by { |group_key, list| [-list.size, group_key] }.
+        group_by { |stat| stat.string_value.object_id }.
+        values.
+        sort_by! { |list| [-list.size, list[0].string_value] }.
         first(top).
-        # Return array of [string, [location, count]]
-        map! { |_group_key, list| [list[0].string_value,
-                                   list.group_by { |stat| stat.location }.
-                                     map { |location, locations| [location, locations.size] } ] }
+        # Return array of [string, [[location, count], [location, count], ...]
+        map! { |list| [list[0].string_value,
+                       list.group_by { |stat| stat.location }.
+                            map { |location, stat_list| [location, stat_list.size] } ] }
     end
 
     # Output the results of the report

--- a/lib/memory_profiler/results.rb
+++ b/lib/memory_profiler/results.rb
@@ -47,10 +47,17 @@ module MemoryProfiler
     end
 
     def string_report(data, top)
-      data.values.
+      grouped_strings = data.values.
         keep_if { |stat| stat.string_value }.
         group_by { |stat| stat.string_value.object_id }.
-        values.
+        values
+
+      if grouped_strings.size > top
+        cutoff = grouped_strings.sort_by!(&:size)[-top].size
+        grouped_strings.keep_if { |list| list.size >= cutoff }
+      end
+
+      grouped_strings.
         sort_by! { |list| [-list.size, list[0].string_value] }.
         first(top).
         # Return array of [string, [[location, count], [location, count], ...]

--- a/lib/memory_profiler/results.rb
+++ b/lib/memory_profiler/results.rb
@@ -58,7 +58,7 @@ module MemoryProfiler
       end
 
       grouped_strings.
-        sort_by! { |list| [-list.size, list[0].string_value] }.
+        sort! { |a, b| a.size == b.size ? a[0].string_value <=> b[0].string_value : b.size <=> a.size }.
         first(top).
         # Return array of [string, [[location, count], [location, count], ...]
         map! { |list| [list[0].string_value,


### PR DESCRIPTION
This PR reduces the memory used creating duplicate strings especially in the case of very long strings which require a lot of memory.

This code builds on the string cache from #51 and @NickLaMuro's md5 ideas in #48 to only store the 200 characters needed for the String Report in the output. The `object_id` of the cached, shorted string summary works like the md5 hash to uniquely identify string allocations even when strings are the same in the first 200 characters.

I reorganzined the `string_report` method to be a little more readable (hopefully) while also introducting the object_id logic. The switch to using end-of-line dot notation makes it possible to have inline comments but I could change that back.

@NickLaMuro I've tested this with the ManageIQ example and it now profiles completely on startup!