### PR TITLE
Use yield rather than block.call

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: ruby
 rvm:
   - 2.1
-  - 2.2.6
-  - 2.3.3
-  - 2.4.0
+  - 2.2.10
+  - 2.3.7
+  - 2.4.4
+  - 2.5.1
   - ruby-head
 before_install:
   - gem install bundler

--- a/lib/memory_profiler/reporter.rb
+++ b/lib/memory_profiler/reporter.rb
@@ -65,7 +65,7 @@ module MemoryProfiler
     def run(&block)
       start
       begin
-        block.call
+        yield
       rescue Exception
         ObjectSpace.trace_object_allocations_stop
         GC.enable

--- a/test/test_reporter.rb
+++ b/test/test_reporter.rb
@@ -216,4 +216,12 @@ class TestReporter < Minitest::Test
     assert_equal(5, results.strings_allocated[0][1][0][1], "The first string was allocated in 5 times in the first location")
   end
 
+  def test_yield_block
+    results = MemoryProfiler.report do
+      # Do not allocate anything
+    end
+    assert_equal(0, results.total_allocated)
+    assert_equal(0, results.total_retained)
+    assert_equal(0, results.retained_objects_by_location.length)
+  end
 end


### PR DESCRIPTION
Starting with ruby 2.5 `block.call` is causing a `Proc` to be allocated during the profiling which is then included in the allocated objects report. Switching to `yield` removes that allocation. The method signature for `run(&block)` was left as-is to make it clear that a block should be passed.

This PR also adds ruby 2.5 and bumps the ruby versions for Travis.

Here is an example of the problem using 2.5.1 with the original version...
```bash
> MemoryProfiler.report {}.pretty_print
Total allocated: 80 bytes (1 objects)
Total retained:  80 bytes (1 objects)

allocated memory by gem
-----------------------------------
        80  memory_profiler/lib

...[snip]...

allocated memory by class
-----------------------------------
        80  Proc

```