### PR TITLE
We need to call GC.start multiple times to fully GC symbols

### DIFF
--- a/lib/memory_profiler/reporter.rb
+++ b/lib/memory_profiler/reporter.rb
@@ -33,6 +33,8 @@ module MemoryProfiler
 
     def start
       GC.start
+      GC.start
+      GC.start
       GC.disable
 
       @generation = GC.count
@@ -45,6 +47,8 @@ module MemoryProfiler
       retained = StatHash.new.compare_by_identity
 
       GC.enable
+      GC.start
+      GC.start
       GC.start
 
       # Caution: Do not allocate any new Objects between the call to GC.start and the completion of the retained

--- a/test/test_reporter.rb
+++ b/test/test_reporter.rb
@@ -235,6 +235,24 @@ class TestReporter < Minitest::Test
     assert_equal(0, results.strings_retained.size, "0 unique strings should be retained")
   end
 
+  def test_symbols_report
+    skip if RUBY_VERSION < "2.3.0".freeze
+
+    string = "this is a string"
+
+    results = create_report do
+      string.to_sym
+    end
+
+    assert_equal(3, results.total_allocated)
+    assert_equal(0, results.total_retained)
+    assert_equal(1, results.strings_allocated.size)
+    assert_equal('String', results.allocated_objects_by_class[0][:data])
+    assert_equal(2, results.allocated_objects_by_class[0][:count])
+    assert_equal('Symbol', results.allocated_objects_by_class[1][:data])
+    assert_equal(1, results.allocated_objects_by_class[1][:count])
+  end
+
   def test_yield_block
     results = MemoryProfiler.report do
       # Do not allocate anything


### PR DESCRIPTION
It seems we're incorrectly reporting strings as retained when profiling dynamic symbols `string.to_sym`

From https://bugs.ruby-lang.org/issues/15088#note-1
> global_symbols.dsymbol_fstr_hash (in
symbol.c) is a GC root, so rb_gc_free_dsymbol needs to be called
to remove the string from dsymbol_fstr_hash by the first
GC.start before the underlying fstring object in
vm->frozen_strings can be freed by the second GC.start call

We need to call `GC.start` at least twice to fully Garbage collected string allocations resulting from calling `to_sym`. 

Before: `1` object retained
```
[1] Memory_profiler(GEM)> require 'memory_profiler'
=> true
[2] Memory_profiler(GEM)> a = "this is a string"
=> "this is a string"
[3] Memory_profiler(GEM)> MemoryProfiler.report { a.to_sym }.pretty_print
Total allocated: 120 bytes (3 objects)
Total retained:  40 bytes (1 objects)

allocated memory by gem
-----------------------------------
       120  other

allocated memory by file
-----------------------------------
       120  (pry)

allocated memory by location
-----------------------------------
       120  (pry):3

allocated memory by class
-----------------------------------
        80  String
        40  Symbol

allocated objects by gem
-----------------------------------
         3  other

allocated objects by file
-----------------------------------
         3  (pry)

allocated objects by location
-----------------------------------
         3  (pry):3

allocated objects by class
-----------------------------------
         2  String
         1  Symbol

retained memory by gem
-----------------------------------
        40  other

retained memory by file
-----------------------------------
        40  (pry)

retained memory by location
-----------------------------------
        40  (pry):3

retained memory by class
-----------------------------------
        40  String

retained objects by gem
-----------------------------------
         1  other

retained objects by file
-----------------------------------
         1  (pry)

retained objects by location
-----------------------------------
         1  (pry):3

retained objects by class
-----------------------------------
         1  String


Allocated String Report
-----------------------------------
         2  "this is a string"
         2  (pry):3


Retained String Report
-----------------------------------
         1  "this is a string"
         1  (pry):3

=> nil
```

After: No objects retained
```
[1] Memory_profiler(GEM)> require 'memory_profiler'
=> true
[2] Memory_profiler(GEM)> a = "this is a string"
=> "this is a string"
[3] Memory_profiler(GEM)> MemoryProfiler.report { a.to_sym }.pretty_print
Total allocated: 120 bytes (3 objects)
Total retained:  0 bytes (0 objects)

allocated memory by gem
-----------------------------------
       120  other

allocated memory by file
-----------------------------------
       120  (pry)

allocated memory by location
-----------------------------------
       120  (pry):4

allocated memory by class
-----------------------------------
        80  String
        40  Symbol

allocated objects by gem
-----------------------------------
         3  other

allocated objects by file
-----------------------------------
         3  (pry)

allocated objects by location
-----------------------------------
         3  (pry):4

allocated objects by class
-----------------------------------
         2  String
         1  Symbol
```

@SamSaffron I wasn't sure If I need to open an issue first before creating a pr. 