### PR TITLE
Prevent internally stored string values from blocking GC of long strings

### DIFF
--- a/lib/memory_profiler/helpers.rb
+++ b/lib/memory_profiler/helpers.rb
@@ -35,7 +35,7 @@ module MemoryProfiler
       # This string is shortened to 200 characters which is what the string report shows
       # The string report can still list unique strings longer than 200 characters
       #   separately because the object_id of the shortened string will be different
-      @string_cache[obj] ||= obj[0,200]
+      @string_cache[obj] ||= String.new << obj[0,200]
     end
   end
 end


### PR DESCRIPTION
This PR addresses the issue in #57 where long(ish) strings that were duplicated would show up in the retained report. The problem was caused by internal string cache that was introduced in #52.

This problem currently affects strings between 23 and 200 characters. Shorter strings do not have a "shared" frozen string reference to a large memory area. Longer strings were being shortened to 200 characters already.

This fix partially restores the earlier logic that created a new copy of the string using `String.new << obj`. Just calling `obj[0,200]` also creates a new copy of the string. But by modifying an empty string the internal Ruby memory allocation does not look to see if it is a copy of an existing string.

There may still be an issue when the block of code being profiled has a return value that is a dup'd string but it was only intermittently failing in Ruby 2.3.