### PR TITLE
Add :scale_bytes flag to MemoryProfiler::Results#pretty_print

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The report method can take a few options:
 * `allow_files`: include only certain files from tracing - can be given as a String, Regexp, or array of Strings
 * `ignore_files`: exclude certain files from tracing - can be given as a String or Regexp
 * `trace`: an array of classes for which you explicitly want to trace object allocations
+* `scale_bytes`: flag to convert byte units (e.g. 183200000 is reported as 183.2 MB, rounds with a precision of 2 decimal digits)
 
 Check out `Reporter#new` for more details.
 

--- a/lib/memory_profiler/results.rb
+++ b/lib/memory_profiler/results.rb
@@ -1,6 +1,18 @@
 module MemoryProfiler
   class Results
 
+    UNIT_PREFIXES = {
+      0 => 'B'.freeze,
+      3 => 'kB'.freeze,
+      6 => 'MB'.freeze,
+      9 => 'GB'.freeze,
+      12 => 'TB'.freeze,
+      15 => 'PB'.freeze,
+      18 => 'EB'.freeze,
+      21 => 'ZB'.freeze,
+      24 => 'YB'.freeze
+    }.freeze
+
     def self.register_type(name, stat_attribute)
       @@lookups ||= []
       @@lookups << [name, stat_attribute]
@@ -46,6 +58,14 @@ module MemoryProfiler
       self
     end
 
+    def scale_bytes(bytes)
+      return "0 B" if bytes.zero?
+
+      scale = Math.log10(bytes).div(3) * 3
+      scale = 24 if scale > 24
+      "#{(bytes / 10.0**scale).round(2)} #{UNIT_PREFIXES[scale]}"
+    end
+
     def string_report(data, top)
       grouped_strings = data.values.
         keep_if { |stat| stat.string_value }.
@@ -76,6 +96,7 @@ module MemoryProfiler
     # @option opts [Integer] :retained_strings how many retained strings to print
     # @option opts [Integer] :allocated_strings how many allocated strings to print
     # @option opts [Boolean] :detailed_report should report include detailed information
+    # @option opts [Boolean] :scale_bytes calculates unit prefixes for the numbers of bytes
     def pretty_print(io = $stdout, **options)
       # Handle the special case that Ruby PrettyPrint expects `pretty_print`
       # to be a customized pretty printing function for a class
@@ -86,8 +107,16 @@ module MemoryProfiler
       color_output = options.fetch(:color_output) { io.respond_to?(:isatty) && io.isatty }
       @colorize = color_output ? Polychrome.new : Monochrome.new
 
-      io.puts "Total allocated: #{total_allocated_memsize} bytes (#{total_allocated} objects)"
-      io.puts "Total retained:  #{total_retained_memsize} bytes (#{total_retained} objects)"
+      if options[:scale_bytes]
+        total_allocated_output = scale_bytes(total_allocated_memsize)
+        total_retained_output = scale_bytes(total_retained_memsize)
+      else
+        total_allocated_output = "#{total_allocated_memsize} bytes"
+        total_retained_output = "#{total_retained_memsize} bytes"
+      end
+
+      io.puts "Total allocated: #{total_allocated_output} (#{total_allocated} objects)"
+      io.puts "Total retained:  #{total_retained_output} (#{total_retained} objects)"
 
       if options[:detailed_report] != false
         io.puts
@@ -95,7 +124,8 @@ module MemoryProfiler
             .product(["memory", "objects"])
             .product(["gem", "file", "location", "class"])
             .each do |(type, metric), name|
-              dump "#{type} #{metric} by #{name}", self.send("#{type}_#{metric}_by_#{name}"), io
+              scale_data = metric == "memory" && options[:scale_bytes]
+              dump "#{type} #{metric} by #{name}", self.send("#{type}_#{metric}_by_#{name}"), io, scale_data
             end
       end
 
@@ -129,12 +159,13 @@ module MemoryProfiler
       nil
     end
 
-    def dump(description, data, io)
+    def dump(description, data, io, scale_data)
       io.puts description
       io.puts @colorize.line("-----------------------------------")
       if data && !data.empty?
         data.each do |item|
-          io.puts "#{item[:count].to_s.rjust(10)}  #{item[:data]}"
+          data_string = scale_data ? scale_bytes(item[:count]) : item[:count].to_s
+          io.puts "#{data_string.rjust(10)}  #{item[:data]}"
         end
       else
         io.puts "NO DATA"

--- a/lib/memory_profiler/results.rb
+++ b/lib/memory_profiler/results.rb
@@ -1,16 +1,15 @@
 module MemoryProfiler
   class Results
-
     UNIT_PREFIXES = {
-      0 => 'B'.freeze,
-      3 => 'kB'.freeze,
-      6 => 'MB'.freeze,
-      9 => 'GB'.freeze,
-      12 => 'TB'.freeze,
-      15 => 'PB'.freeze,
-      18 => 'EB'.freeze,
-      21 => 'ZB'.freeze,
-      24 => 'YB'.freeze
+      0 => 'B',
+      3 => 'kB',
+      6 => 'MB',
+      9 => 'GB',
+      12 => 'TB',
+      15 => 'PB',
+      18 => 'EB',
+      21 => 'ZB',
+      24 => 'YB'
     }.freeze
 
     def self.register_type(name, stat_attribute)

--- a/test/test_results.rb
+++ b/test/test_results.rb
@@ -15,4 +15,40 @@ class TestResults < Minitest::Test
     require 'pp'
     assert_output(/#<MemoryProfiler::Results:\w*>/) { pp(MemoryProfiler::Results.new) }
   end
+
+  def scale_bytes_result
+    MemoryProfiler.report { 1000.times { Array['a'..'z'][Array(0..25).sample] } }
+  end
+
+  def verify_unscaled_result(result, io)
+    total_size = result.total_allocated_memsize
+    array_size = result.allocated_memory_by_class.detect { |h| h[:data] == 'Array' }[:count]
+    assert_match(/^Total allocated: #{total_size} bytes/, io.string, 'The total allocated memsize is unscaled.')
+    assert_match(/^ +#{array_size}  Array$/, io.string, 'The allocated memsize for Array is unscaled.')
+  end
+
+  def test_scale_bytes_default
+    result = scale_bytes_result
+    io = StringIO.new
+    result.pretty_print(io)
+    verify_unscaled_result result, io
+  end
+
+  def test_scale_bytes_off
+    result = scale_bytes_result
+    io = StringIO.new
+    result.pretty_print(io, scale_bytes: false)
+    verify_unscaled_result result, io
+  end
+
+  def test_scale_bytes_true
+    result = scale_bytes_result
+    total_size = result.total_allocated_memsize / 1000.0
+    array_size = result.allocated_memory_by_class.detect { |h| h[:data] == 'Array' }[:count] / 1000.0
+    io = StringIO.new
+    result.pretty_print(io, scale_bytes: true)
+
+    assert_match(/^Total allocated: #{total_size.round(2)} kB/, io.string, 'The total allocated memsize is scaled.')
+    assert_match(/^ +#{array_size.round(2)} kB  Array$/, io.string, 'The allocated memsize for Array is scaled.')
+  end
 end


### PR DESCRIPTION
Hello Sam, I really like your gem, thanks a lot.
While integrating it into our development environment I had a hard time to reason about memory sizes and wished there was a way to scale the unit. The scaled sizes are not exact anymore but I think that is acceptable and one can still get the unscaled values if needed. What do you think?