### PR TITLE
Update documentation and code about ruby < 2.3

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2013 TODO: Write your name
+Copyright (c) 2013 Sam Saffron
 
 MIT License
 

--- a/lib/memory_profiler/reporter.rb
+++ b/lib/memory_profiler/reporter.rb
@@ -88,7 +88,6 @@ module MemoryProfiler
     def object_list(generation)
 
       rvalue_size = GC::INTERNAL_CONSTANTS[:RVALUE_SIZE]
-      rvalue_size_adjustment = RUBY_VERSION < '2.2' ? rvalue_size : 0
       helper = Helpers.new
 
       result = StatHash.new.compare_by_identity
@@ -115,7 +114,7 @@ module MemoryProfiler
 
           # we do memsize first to avoid freezing as a side effect and shifting
           # storage to the new frozen string, this happens on @hash[s] in lookup_string
-          memsize = ObjectSpace.memsize_of(obj) + rvalue_size_adjustment
+          memsize = ObjectSpace.memsize_of(obj)
           string     = klass == String ? helper.lookup_string(obj) : nil
 
           # compensate for API bug

--- a/memory_profiler.gemspec
+++ b/memory_profiler.gemspec
@@ -10,8 +10,8 @@ Gem::Specification.new do |spec|
   spec.version       = MemoryProfiler::VERSION
   spec.authors       = ["Sam Saffron"]
   spec.email         = ["sam.saffron@gmail.com"]
-  spec.description   = %q{Memory profiling routines for Ruby 2.1+}
-  spec.summary       = %q{Memory profiling routines for Ruby 2.1+}
+  spec.description   = %q{Memory profiling routines for Ruby 2.3+}
+  spec.summary       = %q{Memory profiling routines for Ruby 2.3+}
   spec.homepage      = "https://github.com/SamSaffron/memory_profiler"
   spec.license       = "MIT"
 


### PR DESCRIPTION
Memory_profiler requires RUBY_VERSION >= 2.3 since e5a8228b44
updating the documentation about it.
The code part was related to the use of RUBY_VERSION < 2.2
which is no longer possible.