### PR TITLE
Trigger a full_mark GC rather than call it 3 times

### DIFF
--- a/lib/memory_profiler/reporter.rb
+++ b/lib/memory_profiler/reporter.rb
@@ -34,9 +34,9 @@ module MemoryProfiler
     end
 
     def start
-      GC.start
-      GC.start
-      GC.start
+      GC.start(full_mark: true, immediate_sweep: true)
+      GC.start(full_mark: true, immediate_sweep: true)
+      GC.start(full_mark: true, immediate_sweep: true)
       GC.disable
 
       @generation = GC.count
@@ -49,9 +49,9 @@ module MemoryProfiler
       retained = StatHash.new.compare_by_identity
 
       GC.enable
-      GC.start
-      GC.start
-      GC.start
+      GC.start(full_mark: true, immediate_sweep: true)
+      GC.start(full_mark: true, immediate_sweep: true)
+      GC.start(full_mark: true, immediate_sweep: true)
 
       # Caution: Do not allocate any new Objects between the call to GC.start and the completion of the retained
       #          lookups. It is likely that a new Object would reuse an object_id from a GC'd object.


### PR DESCRIPTION
Followup on: https://github.com/SamSaffron/memory_profiler/pull/58

I believe why calling it 3 times seemed to work is that it increase the chances to trigger a `full_mark`, but if it's the intent, might as well as for it directly.

Please correct me if I'm wrong.

@SamSaffron @william101 