### PR TITLE
Improve rounder numbers formatting

### DIFF
--- a/lib/memory_profiler/results.rb
+++ b/lib/memory_profiler/results.rb
@@ -64,7 +64,7 @@ module MemoryProfiler
 
       scale = Math.log10(bytes).div(3) * 3
       scale = 24 if scale > 24
-      "#{(bytes / 10.0**scale).round(2)} #{UNIT_PREFIXES[scale]}"
+      "%.2f #{UNIT_PREFIXES[scale]}" % (bytes / 10.0**scale)
     end
 
     def string_report(data, top)


### PR DESCRIPTION
I got triggered by the inconsistent formatting:

Before:
```
20.75 MB  /tmp/bundle/ruby/2.5.0/gems/bootsnap-1.4.2.rc2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22
 15.1 MB  /tmp/bundle/ruby/2.5.0/gems/psych-3.1.0/lib/psych/scalar_scanner.rb:40
11.18 MB  /tmp/bundle/ruby/2.5.0/gems/graphql-client-0.14.0/lib/graphql/client/schema/enum_type.rb:28
  9.3 MB  /tmp/bundle/ruby/2.5.0/gems/graphql-1.9.3/lib/graphql/define/instance_definable.rb:202
```

After:
```
20.75 MB  /tmp/bundle/ruby/2.5.0/gems/bootsnap-1.4.2.rc2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22
15.10 MB  /tmp/bundle/ruby/2.5.0/gems/psych-3.1.0/lib/psych/scalar_scanner.rb:40
11.18 MB  /tmp/bundle/ruby/2.5.0/gems/graphql-client-0.14.0/lib/graphql/client/schema/enum_type.rb:28
 9.30 MB  /tmp/bundle/ruby/2.5.0/gems/graphql-1.9.3/lib/graphql/define/instance_definable.rb:202
```