### PR TITLE
Reduce array allocations by nesting blocks

### DIFF
--- a/lib/memory_profiler/results.rb
+++ b/lib/memory_profiler/results.rb
@@ -18,8 +18,10 @@ module MemoryProfiler
       @@lookups ||= []
       @@lookups << [name, stat_attribute]
 
-      ["allocated", "retained"].product(["objects", "memory"]).each do |type, metric|
-        attr_accessor "#{type}_#{metric}_by_#{name}"
+      ["allocated", "retained"].each do |type|
+        ["objects", "memory"].each do |metric|
+          attr_accessor "#{type}_#{metric}_by_#{name}"
+        end
       end
     end
 

--- a/lib/memory_profiler/results.rb
+++ b/lib/memory_profiler/results.rb
@@ -123,13 +123,14 @@ module MemoryProfiler
 
       if options[:detailed_report] != false
         io.puts
-        ["allocated", "retained"]
-            .product(["memory", "objects"])
-            .product(["gem", "file", "location", "class"])
-            .each do |(type, metric), name|
+        ["allocated", "retained"].each do |type|
+          ["memory", "objects"].each do |metric|
+            ["gem", "file", "location", "class"].each do |name|
               scale_data = metric == "memory" && options[:scale_bytes]
               dump "#{type} #{metric} by #{name}", self.send("#{type}_#{metric}_by_#{name}"), io, scale_data
             end
+          end
+        end
       end
 
       io.puts

--- a/lib/memory_profiler/results.rb
+++ b/lib/memory_profiler/results.rb
@@ -14,12 +14,16 @@ module MemoryProfiler
       24 => 'YB'
     }.freeze
 
+    TYPES   = ["allocated", "retained"].freeze
+    METRICS = ["memory", "objects"].freeze
+    NAMES   = ["gem", "file", "location", "class"].freeze
+
     def self.register_type(name, stat_attribute)
       @@lookups ||= []
       @@lookups << [name, stat_attribute]
 
-      ["allocated", "retained"].each do |type|
-        ["objects", "memory"].each do |metric|
+      TYPES.each do |type|
+        METRICS.each do |metric|
           attr_accessor "#{type}_#{metric}_by_#{name}"
         end
       end
@@ -123,9 +127,9 @@ module MemoryProfiler
 
       if options[:detailed_report] != false
         io.puts
-        ["allocated", "retained"].each do |type|
-          ["memory", "objects"].each do |metric|
-            ["gem", "file", "location", "class"].each do |name|
+        TYPES.each do |type|
+          METRICS.each do |metric|
+            NAMES.each do |name|
               scale_data = metric == "memory" && options[:scale_bytes]
               dump "#{type} #{metric} by #{name}", self.send("#{type}_#{metric}_by_#{name}"), io, scale_data
             end


### PR DESCRIPTION
Calling `Array#product` leads to unnecessary array allocations.
Instead nesting blocks bypasses allocations which also provides a minor speed boost.

## Benchmark script
```ruby
# frozen_string_literal: true

require 'benchmark/ips'
require 'bundler/setup'
require 'memory_profiler'

def product
  bucket = []
  ["allocated", "retained"].product(["objects", "memory"]).each do |type, metric|
    bucket << "#{type} #{metric}"
  end
  bucket
end

def nested_blocks
  bucket = []
  ["allocated", "retained"].each do |type|
    ["objects", "memory"].each do |metric|
      bucket << "#{type} #{metric}"
    end
  end
  bucket
end

def profile(label, &block)
  puts "-"*80
  puts "Profiling #{label}"
  puts "-"*80
  reporter = MemoryProfiler.report(trace: [Array], &block)
  reporter.pretty_print(detailed_report: false, scale_bytes: true)
  puts "\n\n"
end

if product == nested_blocks
  profile("array product") { product }
  profile("nested blocks") { nested_blocks }
  puts "Running Benchmark.."
  Benchmark.ips do |x|
    x.report("array product") { product }
    x.report("nested blocks") { nested_blocks }
    x.compare!
  end
end
```