### PR TITLE
Separate multiple method chains by newlines

### DIFF
--- a/lib/memory_profiler/results.rb
+++ b/lib/memory_profiler/results.rb
@@ -73,26 +73,29 @@ module MemoryProfiler
     end
 
     def string_report(data, top)
-      grouped_strings = data.values.
-        keep_if { |stat| stat.string_value }.
-        group_by { |stat| stat.string_value.object_id }.
-        values
+      grouped_strings = data.values
+        .keep_if  { |stat| stat.string_value }
+        .group_by { |stat| stat.string_value.object_id }
+        .values
 
       if grouped_strings.size > top
         cutoff = grouped_strings.sort_by!(&:size)[-top].size
         grouped_strings.keep_if { |list| list.size >= cutoff }
       end
 
-      grouped_strings.
-        sort! { |a, b| a.size == b.size ? a[0].string_value <=> b[0].string_value : b.size <=> a.size }.
-        first(top).
-        # Return array of [string, [[location, count], [location, count], ...]
-        map! { |list| [list[0].string_value,
-                       list.group_by { |stat| stat.location }.
-                         map { |location, stat_list| [location, stat_list.size] }.
-                         sort_by!(&:last).reverse!
-                      ]
-        }
+      grouped_strings
+        .sort! { |a, b| a.size == b.size ? a[0].string_value <=> b[0].string_value : b.size <=> a.size }
+        .first(top)
+        .map! do |list|
+          # Return array of [string, [[location, count], [location, count], ...]
+          [
+            list[0].string_value,
+            list.group_by { |stat| stat.location }
+              .map { |location, stat_list| [location, stat_list.size] }
+              .sort_by!(&:last)
+              .reverse!
+          ]
+        end
     end
 
     # Output the results of the report

--- a/lib/memory_profiler/top_n.rb
+++ b/lib/memory_profiler/top_n.rb
@@ -6,17 +6,26 @@ module MemoryProfiler
     # Returns results for both memory (memsize summed) and objects allocated (count) as a tuple.
     def top_n(max, metric_method)
 
-      stat_totals = self.values.group_by(&metric_method).map do |metric, stats|
-        [metric, stats.reduce(0) { |sum, stat| sum + stat.memsize }, stats.size]
-      end
+      stat_totals =
+        self.values
+          .group_by(&metric_method)
+          .map do |metric, stats|
+            [metric, stats.reduce(0) { |sum, stat| sum + stat.memsize }, stats.size]
+          end
 
-      stats_by_memsize = stat_totals.sort_by! { |metric, memsize, _count| [-memsize, metric] }.take(max).
-        map! { |metric, memsize, _count| { data: metric, count: memsize } }
-      stats_by_count = stat_totals.sort_by! { |metric, _memsize, count| [-count, metric] }.take(max).
-        map! { |metric, _memsize, count| { data: metric, count: count } }
+      stats_by_memsize =
+        stat_totals
+          .sort_by! { |metric, memsize, _count| [-memsize, metric] }
+          .take(max)
+          .map! { |metric, memsize, _count| { data: metric, count: memsize } }
+
+      stats_by_count =
+        stat_totals
+          .sort_by! { |metric, _memsize, count| [-count, metric] }
+          .take(max)
+          .map! { |metric, _memsize, count| { data: metric, count: count } }
 
       [stats_by_memsize, stats_by_count]
-
     end
   end
 end


### PR DESCRIPTION
This is purely a style change.

Ruby libraries I've come across tend to separate long method chains using *newline-followed-by-the-dot* instead of *dot-followed-by-newline*.

The impact on readability is however subjective.
Let me know if there are any programmatic reasons for opting for the current *dot-followed-by-newline* approach.