### PR TITLE
Allow stripping gem dir path from location data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :development, :test do
+  gem 'json', '2.2.0', require: false
   gem 'rake', require: false
   gem 'minitest', require: false
   gem 'guard', platforms: [:mri_22, :mri_23]

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ The `pretty_print` method can take a few options:
 * `allocated_strings`: how many allocated strings to print - can be given a String
 * `detailed_report`: should report include detailed information - can be given a Boolean
 * `scale_bytes`: flag to convert byte units (e.g. 183200000 is reported as 183.2 MB, rounds with a precision of 2 decimal digits) - can be given a Boolean
+* `normalize_paths`: flag to remove default Rubygems installation directory path from printed locations - can be given a Boolean
 
 Check out `Results#pretty_print` for more details.
 

--- a/test/test_results.rb
+++ b/test/test_results.rb
@@ -53,4 +53,33 @@ class TestResults < Minitest::Test
     assert_match(/^Total allocated: #{"%.2f" % total_size} kB/, io.string, 'The total allocated memsize is scaled.')
     assert_match(/^ +#{"%.2f" % array_size} kB  Array$/, io.string, 'The allocated memsize for Array is scaled.')
   end
+
+  def normalized_paths_report
+    MemoryProfiler.report do
+      require 'json'
+      JSON.generate(lorem: 'ipsum', foo: 'bar', alpha: 'delta')
+    end
+  end
+
+  def test_normalize_paths_default
+    report = normalized_paths_report
+    io = StringIO.new
+    report.pretty_print(io)
+    assert_match(%r!(/gems/.*?)*/gems/json-2.2.0/lib/json/common.rb!, io.string)
+  end
+
+  def test_normalize_paths_false
+    report = normalized_paths_report
+    io = StringIO.new
+    report.pretty_print(io, normalize_paths: false)
+    assert_match(%r!(/gems/.*?)*/gems/json-2.2.0/lib/json/common.rb!, io.string)
+  end
+
+  def test_normalize_paths_true
+    report = normalized_paths_report
+    io = StringIO.new
+    report.pretty_print(io, normalize_paths: true)
+    refute_match(%r!(/gems/.*?)*/gems/json-2.2.0/lib/json/common.rb!, io.string)
+    assert_match(%r!json-2.2.0/lib/json/common.rb!, io.string)
+  end
 end


### PR DESCRIPTION
Partially resolves #64 

With this, passing `normalize_paths: true` to `#pretty_print` will strip default Rubygems directory path from all *printed location paths*.

As of now, the gem paths in non-default directories (`/vendor/bundle/`, git clone director(ies), etc) are not *normalized*.