### PR TITLE
Allow normalizing paths in pretty_print output

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,5 @@ group :development, :test do
   gem 'minitest', require: false
   gem 'guard', platforms: [:mri_22, :mri_23]
   gem 'guard-minitest', platforms: [:mri_22, :mri_23]
+  gem 'longhorn', path: 'test/fixtures/gems/longhorn-0.1.0'
 end

--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ The `pretty_print` method can take a few options:
 * `allocated_strings`: how many allocated strings to print - can be given a String
 * `detailed_report`: should report include detailed information - can be given a Boolean
 * `scale_bytes`: flag to convert byte units (e.g. 183200000 is reported as 183.2 MB, rounds with a precision of 2 decimal digits) - can be given a Boolean
+* `normalize_paths`: flag to remove a gem's directory path from printed locations - can be given a Boolean
+*Note: normalized path of a "location" from Ruby's stdlib will be prefixed with `ruby/lib/`. e.g.: `ruby/lib/set.rb`, `ruby/lib/pathname.rb`, etc.*
+
 
 Check out `Results#pretty_print` for more details.
 

--- a/test/fixtures/gems/longhorn-0.1.0/lib/longhorn.rb
+++ b/test/fixtures/gems/longhorn-0.1.0/lib/longhorn.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'set'
+
+module Longhorn
+  def self.run
+    result = Set.new
+    ["allocated", "retained"]
+      .product(["memory", "objects"])
+      .product(["gem", "file", "location", "class"])
+      .each do |(type, metric), name|
+        result << "#{type} #{metric} by #{name}"
+      end
+    result
+  end
+end

--- a/test/fixtures/gems/longhorn-0.1.0/longhorn.gemspec
+++ b/test/fixtures/gems/longhorn-0.1.0/longhorn.gemspec
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+Gem::Specification.new do |s|
+  s.name     = "longhorn"
+  s.version  = "0.1.0"
+  s.licenses = ["MIT"]
+  s.summary  = "A gem to test MemoryProfiler"
+  s.authors  = ["John Doe"]
+  s.files    = ["lib/longhorn.rb"]
+  s.homepage = "https://github.com/SamSaffron/memory_profiler"
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,3 +4,11 @@ require 'memory_profiler'
 require 'minitest/pride'
 require 'minitest/autorun'
 require_relative 'test_helpers'
+
+FIXTURE_DIR = File.expand_path('fixtures', __dir__).freeze
+
+def require_fixture_gem(name)
+  lib_path = File.join(FIXTURE_DIR, 'gems', "#{name}-0.1.0", 'lib')
+  $LOAD_PATH.unshift(lib_path) unless $LOAD_PATH.include?(lib_path)
+  require name
+end

--- a/test/test_results.rb
+++ b/test/test_results.rb
@@ -53,4 +53,33 @@ class TestResults < Minitest::Test
     assert_match(/^Total allocated: #{"%.2f" % total_size} kB/, io.string, 'The total allocated memsize is scaled.')
     assert_match(/^ +#{"%.2f" % array_size} kB  Array$/, io.string, 'The allocated memsize for Array is scaled.')
   end
+
+  def normalized_paths_report
+    MemoryProfiler.report do
+      require_fixture_gem 'longhorn'
+      Longhorn.run
+    end
+  end
+
+  def test_normalize_paths_default
+    report = normalized_paths_report
+    io = StringIO.new
+    report.pretty_print(io)
+    assert_match(%r!fixtures/gems/longhorn-0.1.0/lib/longhorn.rb!, io.string)
+  end
+
+  def test_normalize_paths_false
+    report = normalized_paths_report
+    io = StringIO.new
+    report.pretty_print(io, normalize_paths: false)
+    assert_match(%r!fixtures/gems/longhorn-0.1.0/lib/longhorn.rb!, io.string)
+  end
+
+  def test_normalize_paths_true
+    report = normalized_paths_report
+    io = StringIO.new
+    report.pretty_print(io, normalize_paths: true)
+    assert_match(%r!\d+\s{2}longhorn-0.1.0/lib/longhorn.rb:\d+!, io.string)
+    assert_match(%r!ruby/lib/set.rb!, io.string)
+  end
 end


### PR DESCRIPTION
Pass `normalize_paths: true` to `Results#pretty_print` to have location paths stripped of
their gem's parent directories.
Additionally, paths from Ruby's stdlib will have `ruby/lib/` prefixed to their relative paths.

Examples:
  * `/usr/Ruby-2.4.5/lib/ruby/gems/2.4.0/gems/json-2.2.0/lib/json/common.rb`
    will be normalized into `json-2.2.0/lib/json/common.rb`
  * `/usr/Ruby-2.4.5/lib/ruby/2.4.0/pathname.rb` will be normalized into
    `ruby/lib/pathname.rb`

Resolves #64 