### PR TITLE
CI: Drop unused sudo: false directive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ rvm:
 before_install:
   - gem install bundler
 cache: bundler
-sudo: false
 
 matrix:
   allow_failures:


### PR DESCRIPTION
  - Blog post where they mention it is removed https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration