### PR TITLE
Some small optimizations for Ruby 2.7

### DIFF
--- a/lib/memory_profiler/reporter.rb
+++ b/lib/memory_profiler/reporter.rb
@@ -99,11 +99,7 @@ module MemoryProfiler
         next if @ignore_files && @ignore_files =~ file
         next if @allow_files && !(@allow_files =~ file)
 
-        klass = obj.class rescue nil
-        unless Class === klass
-          # attempt to determine the true Class when .class returns something other than a Class
-          klass = Kernel.instance_method(:class).bind(obj).call
-        end
+        klass = helper.object_class(obj)
         next if @trace && !trace.include?(klass)
 
         begin


### PR DESCRIPTION
This leverage 2 Ruby 2.7 changes.

First `UnboundMethod#bind_call`, this allow to call the method on the target object without an extra allocation:

```
              .class     19.849M (± 1.7%) i/s -     99.301M in   5.004209s
          .bind_call      7.444M (± 1.7%) i/s -     37.219M in   5.001481s
          .bind.call      3.027M (± 2.2%) i/s -     15.182M in   5.018714s
```

While I was at it I also cached the `Kernel.instance_method(:class)` as it also allocate a new `UnboundMethod` instance each time.

The second is that since Ruby 2.7, `Module#name` no longer duplicate the name string, and is also much faster because it has a direct pointer to the String rather than having to lookup the constant table.