### PR TITLE
Enhance program CLI

### DIFF
--- a/bin/ruby-memory-profiler
+++ b/bin/ruby-memory-profiler
@@ -1,11 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift("#{__dir__}/../lib")
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 
 require "memory_profiler"
 
-cli = MemoryProfiler::CLI.new
-result = cli.run(ARGV)
-
-exit result
+exit MemoryProfiler::CLI.new.run(ARGV)

--- a/lib/memory_profiler/cli.rb
+++ b/lib/memory_profiler/cli.rb
@@ -4,21 +4,42 @@ require "optparse"
 
 module MemoryProfiler
   class CLI
+    BIN_NAME     = "ruby-memory-profiler"
+    VERSION_INFO = "#{BIN_NAME}  #{MemoryProfiler::VERSION}"
+
     STATUS_SUCCESS = 0
     STATUS_ERROR   = 1
+
+    DEFAULTS = {
+      ignore_files: "memory_profiler/lib"
+    }.freeze
+
+    REPORTER_KEYS = [
+      :top, :trace, :ignore_files, :allow_files
+    ].freeze
+
+    RESULTS_KEYS = [
+      :to_file, :color_output, :retained_strings, :allocated_strings,
+      :detailed_report, :scale_bytes, :normalize_paths
+    ].freeze
+
+    private_constant :BIN_NAME, :VERSION_INFO,:STATUS_SUCCESS, :STATUS_ERROR,
+                     :DEFAULTS, :REPORTER_KEYS, :RESULTS_KEYS
+
+    #
 
     def run(argv)
       options = {}
       parser = option_parser(options)
       parser.parse!(argv)
 
-      options = defaults.merge(options)
+      options = DEFAULTS.merge(options)
 
       # Make sure the user specified at least one file
       unless (script = argv.shift)
         puts parser
         puts ""
-        puts "Must specify a script to run"
+        puts "#{VERSION_INFO}  |  ERROR: Must specify a script to run"
         return STATUS_ERROR
       end
 
@@ -40,19 +61,23 @@ module MemoryProfiler
     def option_parser(options)
       OptionParser.new do |opts|
         opts.banner = <<~BANNER
-          ruby-memory-profiler #{MemoryProfiler::VERSION}
-          Usage: ruby-memory-profiler [options] <script.rb> [--] [script-options]
+
+              #{VERSION_INFO}
+              A Memory Profiler for Ruby
+
+          Usage:
+              #{BIN_NAME} [options] <script.rb> [--] [script-options]
         BANNER
 
         opts.separator ""
         opts.separator "Options:"
 
         # Reporter options
-        opts.on("-m", "--max=NUM", Integer, "Max number of entries to output.") do |arg|
+        opts.on("-m", "--max=NUM", Integer, "Max number of entries to output. (Defaults to 50)") do |arg|
           options[:top] = arg
         end
 
-        opts.on("--classes=CLASSES", Array, "A class or an array of classes you explicitly want to trace.") do |arg|
+        opts.on("--classes=CLASSES", Array, "A class or list of classes you explicitly want to trace.") do |arg|
           options[:trace] = arg.map { |klass| Object.const_get(klass) }
         end
 
@@ -60,16 +85,18 @@ module MemoryProfiler
           options[:ignore_files] = "#{arg}|memory_profiler/lib"
         end
 
-        opts.on("--allow-files=FILES", Array, "A string or array of strings to selectively include in tracing.") do |arg|
+        opts.on("--allow-files=FILES", Array, "A string or list of strings to selectively include in tracing.") do |arg|
           options[:allow_files] = arg
         end
+
+        opts.separator ""
 
         # Results options
         opts.on("-o", "--out=FILE", "Write output to a file instead of STDOUT.") do |arg|
           options[:to_file] = arg
         end
 
-        opts.on("--[no-]color", "Force color output on or off.") do |arg|
+        opts.on("--[no-]color", "Force color output on or off. (Enabled by default)") do |arg|
           options[:color_output] = arg
         end
 
@@ -81,7 +108,7 @@ module MemoryProfiler
           options[:allocated_strings] = arg
         end
 
-        opts.on("--[no-]detailed-report", "Print detailed information.") do |arg|
+        opts.on("--[no-]detailed", "Print detailed information. (Enabled by default)") do |arg|
           options[:detailed_report] = arg
         end
 
@@ -93,31 +120,30 @@ module MemoryProfiler
           options[:normalize_paths] = true
         end
 
-        opts.on_tail("-h", "--help", "Show help message.") do
+        opts.on("--pretty", "Easily enable options 'scale-bytes' and 'normalize-paths'") do
+          options[:scale_bytes] = options[:normalize_paths] = true
+        end
+
+        opts.separator ""
+
+        opts.on_tail("-h", "--help", "Show this help message.") do
           puts opts
           exit
         end
 
-        opts.on_tail("-v", "--version", "Show version.") do
-          puts "ruby-memory-profiler #{MemoryProfiler::VERSION}"
+        opts.on_tail("-v", "--version", "Show program version.") do
+          puts VERSION_INFO
           exit
         end
       end
     end
 
     def reporter_options(options)
-      options.select { |k, _v| [:top, :trace, :ignore_files, :allow_files].include?(k) }
+      options.select { |k, _v| REPORTER_KEYS.include?(k) }
     end
 
     def results_options(options)
-      options.select { |k, _v| [:to_file, :color_output, :retained_strings, :allocated_strings,
-                    :detailed_report, :scale_bytes, :normalize_paths].include?(k) }
-    end
-
-    def defaults
-      {
-        ignore_files: "memory_profiler/lib"
-      }
+      options.select { |k, _v| RESULTS_KEYS.include?(k) }
     end
   end
 end

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -60,13 +60,13 @@ class TestCLI < Minitest::Test
 
   def test_detailed_report
     assert_output(/allocated objects by location\n--------/) do
-      @cli.run(["--detailed-report", @script_file])
+      @cli.run(["--detailed", @script_file])
     end
   end
 
   def test_no_detailed_report
     out, _err = capture_io do
-      @cli.run(["--no-detailed-report", @script_file])
+      @cli.run(["--no-detailed", @script_file])
     end
     refute_includes out, "allocated objects by location\n--------"
   end
@@ -80,6 +80,16 @@ class TestCLI < Minitest::Test
       @cli.run(["--normalize-paths", @script_file])
     end
 
+    assert_match(%r!\d+\s{2}longhorn-0.1.0/lib/longhorn.rb:\d+!, out)
+    assert_match(%r!ruby/lib/set.rb!, out)
+  end
+
+  def test_pretty
+    out, _err = capture_io do
+      @cli.run(["--pretty", @script_file])
+    end
+
+    assert_match(/\d kB/, out)
     assert_match(%r!\d+\s{2}longhorn-0.1.0/lib/longhorn.rb:\d+!, out)
     assert_match(%r!ruby/lib/set.rb!, out)
   end


### PR DESCRIPTION
Enhances the CLI output to:

```
$ ruby-memory-profiler

    ruby-memory-profiler  0.9.14
    A Memory Profiler for Ruby

Usage:
    ruby-memory-profiler [options] <script.rb> [--] [script-options]

Options:
    -m, --max=NUM                    Max number of entries to output. (Defaults to 50)
        --classes=CLASSES            A class or list of classes you explicitly want to trace.
        --ignore-files=REGEXP        A regular expression used to exclude certain files from tracing.
        --allow-files=FILES          A string or list of strings to selectively include in tracing.

    -o, --out=FILE                   Write output to a file instead of STDOUT.
        --[no-]color                 Force color output on or off. (Enabled by default)
        --retained-strings=NUM       How many retained strings to print.
        --allocated-strings=NUM      How many allocated strings to print.
        --[no-]detailed              Print detailed information. (Enabled by default)
        --scale-bytes                Calculates unit prefixes for the numbers of bytes.
        --normalize-paths            Print location paths relative to gem's source directory.
        --pretty                     Easily enable options 'scale-bytes' and 'normalize-paths'

    -h, --help                       Show this help message.
    -v, --version                    Show program version.

ruby-memory-profiler  0.9.14  |  ERROR: Must specify a script to run
```

### Notable Changes

- adds `--pretty` switch to enable `--scale-bytes` and `--normalize-paths` easily
- changes `--[no-]detailed-report` to `--[no-]detailed` to reduce keystrokes

/cc @fatkodima for feedback.