### PR TITLE
GC.start in times block rather than 3x calls

### DIFF
--- a/lib/memory_profiler/reporter.rb
+++ b/lib/memory_profiler/reporter.rb
@@ -34,7 +34,7 @@ module MemoryProfiler
     end
 
     def start
-      3.times { GC.start }
+      4.times { GC.start }
       GC.disable
 
       @generation = GC.count
@@ -47,7 +47,7 @@ module MemoryProfiler
       retained = StatHash.new.compare_by_identity
 
       GC.enable
-      3.times { GC.start }
+      4.times { GC.start }
 
       # Caution: Do not allocate any new Objects between the call to GC.start and the completion of the retained
       #          lookups. It is likely that a new Object would reuse an object_id from a GC'd object.

--- a/lib/memory_profiler/reporter.rb
+++ b/lib/memory_profiler/reporter.rb
@@ -34,9 +34,7 @@ module MemoryProfiler
     end
 
     def start
-      GC.start
-      GC.start
-      GC.start
+      3.times { GC.start }
       GC.disable
 
       @generation = GC.count
@@ -49,9 +47,7 @@ module MemoryProfiler
       retained = StatHash.new.compare_by_identity
 
       GC.enable
-      GC.start
-      GC.start
-      GC.start
+      3.times { GC.start }
 
       # Caution: Do not allocate any new Objects between the call to GC.start and the completion of the retained
       #          lookups. It is likely that a new Object would reuse an object_id from a GC'd object.


### PR DESCRIPTION
Closes #96

For some reason calling GC inside a times block improves the reliability of retained objects.