### PR TITLE
Breakdown of Total/shared strings in the retained/allocated lists

### DIFF
--- a/lib/memory_profiler/stat.rb
+++ b/lib/memory_profiler/stat.rb
@@ -5,7 +5,9 @@ module MemoryProfiler
 
     attr_reader :class_name, :gem, :file, :location, :memsize, :string_value
 
-    def initialize(class_name, gem, file, location, memsize, string_value)
+    attr_reader :shared
+
+    def initialize(class_name, gem, file, location, memsize, string_value, shared)
       @class_name = class_name
       @gem = gem
 
@@ -14,6 +16,8 @@ module MemoryProfiler
 
       @memsize = memsize
       @string_value = string_value
+
+      @shared = shared
     end
 
   end


### PR DESCRIPTION
This MR adds extra information about strings (whether they're internally shared), and displays this information in the string report breakdown. Example from some local tests:

```
Allocated String Report (Total/Shared)
-----------------------------------
      10/0  ""
       4/0  /user/dev/http-2-next/lib/http/2/next/extensions.rb:17
       4/0  /user/dev/http-2-next/lib/http/2/next/extensions.rb:18
       1/0  /user/dev/http-2-next/lib/http/2/next/framer.rb:372
       1/0  /user/dev/http-2-next/lib/http/2/next/framer.rb:415

       4/4  "\x00\x00\x0E\x01\x04\x00\x00\x00\x01\x88\\\x0227_\x87I|\xA5\x8A\xE8\x19\xAA\x00\x00\x05\x00\x00\x00\x00\x00\x01Hello\x00\x00\x00\x00\x01\x00\x00\x00\x01"
       4/4  /user/http-2-next/lib/http/2/next/extensions.rb:18

       4/0  "1"
       4/0  /user/dev/http-2-next/example/helper.rb:27
...
```

@SamSaffron I know you mentioned that this should be an optional feature. For now it's not, as I'd like to open the conversation of whether this should not be considered the new default (for a breaking change), as I think it's generally useful information (one would like to know, if the number of string allocations grows, whether these are optimized internally), however there might be counter-arguments, so I'd like to discuss them before turning this into an opt-in.



