### PR TITLE
Migrate from actions/setup-ruby to ruby/setup-ruby

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,20 +15,9 @@ jobs:
         ruby: ["2.7", "2.6", "2.5"]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - name: Bundler cache
-        uses: actions/cache@v2
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-${{ matrix.ruby }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.ruby }}-gems-
-      - name: Setup gems
-        run: |
-          gem install bundler
-          bundle config path vendor/bundle
-          bundle install --jobs 4
+          bundler-cache: true
       - name: Tests
         run: bundle exec rake test


### PR DESCRIPTION
https://github.com/actions/setup-ruby says

> This action is deprecated and should no longer be used. [...] Please, migrate your workflows to the ruby/setup-ruby [...]

The `ruby/setup-ruby` action makes gem installation and caching really; it’s literally just adding one line.