### PR TITLE
Compute report lazily

### DIFF
--- a/lib/memory_profiler/top_n.rb
+++ b/lib/memory_profiler/top_n.rb
@@ -5,32 +5,40 @@ module MemoryProfiler
     # Fast approach for determining the top_n entries in a Hash of Stat objects.
     # Returns results for both memory (memsize summed) and objects allocated (count) as a tuple.
     def top_n(max, metric_method)
+      [
+        top_n_memory(max, metric_method),
+        top_n_objects(max, metric_method)
+      ]
+    end
 
+    def top_n_memory(max, metric_method)
       metric_memsize = Hash.new(0)
+
+      each_value do |value|
+        metric = value.send(metric_method)
+        metric_memsize[metric] += value.memsize
+      end
+
+      metric_memsize
+        .to_a
+        .sort_by! { |metric, memsize| [-memsize, metric] }
+        .take(max)
+        .map! { |metric, memsize| { data: metric, count: memsize } }
+    end
+
+    def top_n_objects(max, metric_method)
       metric_objects_count = Hash.new(0)
 
       each_value do |value|
         metric = value.send(metric_method)
-
-        metric_memsize[metric] += value.memsize
         metric_objects_count[metric] += 1
       end
 
-      stats_by_memsize =
-        metric_memsize
-          .to_a
-          .sort_by! { |metric, memsize| [-memsize, metric] }
-          .take(max)
-          .map! { |metric, memsize| { data: metric, count: memsize } }
-
-      stats_by_count =
-        metric_objects_count
-          .to_a
-          .sort_by! { |metric, count| [-count, metric] }
-          .take(max)
-          .map! { |metric, count| { data: metric, count: count } }
-
-      [stats_by_memsize, stats_by_count]
+      metric_objects_count
+        .to_a
+        .sort_by! { |metric, count| [-count, metric] }
+        .take(max)
+        .map! { |metric, count| { data: metric, count: count } }
     end
   end
 end

--- a/test/test_results.rb
+++ b/test/test_results.rb
@@ -15,7 +15,7 @@ class TestResults < Minitest::Test
 
   def test_no_conflict_with_pretty_print
     require 'pp'
-    assert_output(/#<MemoryProfiler::Results:\w*>/) { pp(MemoryProfiler::Results.new) }
+    assert_output(/#<MemoryProfiler::Results:.*/) { pp(MemoryProfiler::Results.new) }
   end
 
   def scale_bytes_result


### PR DESCRIPTION
Currently, `memory_profiler` calculates report eagerly, which wastes time/memory and may not always be needed. 

For example, I usually disable strings report by `.pretty_print(retained_strings: 0, allocated_strings: 0)`. 
Or someone can use `.pretty_print(detailed_report: false)`.

In this PR, report is computed lazily.

Tested on `rubocop`'s codebase (ran rubocop on its own `lib/rubocop/cop/style` files - 222 files).

## Time
### Before
```
222 files inspected, no offenses detected
Building memory report...
Finished in 77.41 seconds
```

### After
```
222 files inspected, no offenses detected
Building memory report...
Finished in 54.59 seconds
```

## Memory (generated by memory_profiler itself)
### Before
```
Total allocated: 47.76 MB (305368 objects)
Total retained:  508.08 kB (8818 objects)

allocated memory by gem
-----------------------------------
  47.76 MB  memory_profiler/lib

allocated memory by file
-----------------------------------
  43.79 MB  /Users/fatkodima/Desktop/oss/memory_profiler/lib/memory_profiler/results.rb
   3.96 MB  /Users/fatkodima/Desktop/oss/memory_profiler/lib/memory_profiler/top_n.rb
  728.00 B  /Users/fatkodima/Desktop/oss/memory_profiler/lib/memory_profiler/reporter.rb
...
```

### After
```
Total allocated: 9.81 kB (19 objects)
Total retained:  352.00 B (3 objects)

allocated memory by gem
-----------------------------------
   9.81 kB  memory_profiler/lib

allocated memory by file
-----------------------------------
   9.22 kB  /Users/fatkodima/Desktop/oss/memory_profiler/lib/memory_profiler/results.rb
  584.00 B  /Users/fatkodima/Desktop/oss/memory_profiler/lib/memory_profiler/reporter.rb
...
```