### PR TITLE
fix README.md `allocated_strings` type

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The `pretty_print` method can take a few options:
 * `to_file`: a path to your log file - can be given a String
 * `color_output`: a flag for whether to colorize output - can be given a Boolean
 * `retained_strings`: how many retained strings to print - can be given an Integer
-* `allocated_strings`: how many allocated strings to print - can be given a String
+* `allocated_strings`: how many allocated strings to print - can be given a Integer
 * `detailed_report`: should report include detailed information - can be given a Boolean
 * `scale_bytes`: flag to convert byte units (e.g. 183200000 is reported as 183.2 MB, rounds with a precision of 2 decimal digits) - can be given a Boolean
 * `normalize_paths`: flag to remove a gem's directory path from printed locations - can be given a Boolean


### PR DESCRIPTION
It did not match the type on the code side, so fixed it.
https://github.com/SamSaffron/memory_profiler/blob/master/lib/memory_profiler/results.rb#L109