### PR TITLE
CI: bumps actions/checkout to address Node 12 deprecation warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         ruby: ["2.6", "2.7", "3.0", "3.1", "3.2"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}


### PR DESCRIPTION
Bumping to v3 fixes Node.js 12 deprecation warnings. To keep the GH Action functional, `actions/checkout` needs to be updated. See https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

I also noticed, that CI is testing Ruby >= 2.6, while README states Ruby >= 2.5 is supported.