### PR TITLE
Add ability to profile commands via CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add ability to profile commands via CLI @fatkodima
+
 ## 1.0.1 - 23-10-2022
 
 - Adapts tests to Ruby 3.0 / 3.1

--- a/README.md
+++ b/README.md
@@ -32,14 +32,23 @@ There are two ways to use `memory_profiler`:
 ### Command Line
 
 The easiest way to use memory_profiler is via the command line, which requires no modifications to your program. The basic usage is:
+
 ```
-$ ruby-memory-profiler [options] <script.rb> [--] [script-options]
+$ ruby-memory-profiler [options] run [--] command [command-options]
 ```
-Where `script.rb` is the program you want to profile.
+
+Example:
+
+```
+$ ruby-memory-profiler --pretty run -- rubocop --cache false
+
+$ ruby-memory-profiler --max=10 --pretty run -- ruby notify_users.rb 1 2 3 --quiet
+```
 
 For a full list of options, execute the following command:
+
 ```
-ruby-memory-profiler -h
+$ ruby-memory-profiler -h
 ```
 
 ### Convenience API

--- a/lib/memory_profiler/autorun.rb
+++ b/lib/memory_profiler/autorun.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "memory_profiler"
+require "base64"
+
+def deserialize_hash(data)
+  Marshal.load(Base64.urlsafe_decode64(data)) if data
+end
+
+options = deserialize_hash(ENV["MEMORY_PROFILER_OPTIONS"]) || {}
+
+at_exit do
+  report = MemoryProfiler.stop
+  report.pretty_print(**options)
+end
+
+MemoryProfiler.start(options)

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -111,4 +111,9 @@ class TestCLI < Minitest::Test
       assert_equal 1, result
     end
   end
+
+  def test_profiles_commands
+    out = `bin/ruby-memory-profiler --pretty run -- ruby -e '[]'`
+    assert_includes(out, "Total allocated:")
+  end
 end

--- a/test/test_reporter.rb
+++ b/test/test_reporter.rb
@@ -12,7 +12,7 @@ class TestReporter < Minitest::Test
   def default_block
     # Create an object from a gem outside memory_profiler which allocates
     # its own objects internally
-    MiniTest::Reporter.new
+    Minitest::Reporter.new
 
     # Create 10 strings
     10.times { |i| i.to_s }


### PR DESCRIPTION
Closes #113.
Closes #114.

Currently, the CLI allows to profile only ruby files. But when you want to profile a whole ruby command for its entire lifetime, it's a bit complicated to find the proper entry point and exit point to insert `MemoryProfiler.start` etc.

This PR extends the CLI to allow to do this easily, e.g:

```
$ ruby-memory-profiler run -- rubocop --cache false
```

Or for profiling a Rails application boot sequence:

```
$ ruby-memory-profiler run -- bin/rails runner ':ok'
```

Or a user's rake task:

```
$ ruby-memory-profiler run -- bin/rake users:notify
```