### PR TITLE
Fix tests

### DIFF
--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -81,7 +81,7 @@ class TestCLI < Minitest::Test
     end
 
     assert_match(%r!\d+\s{2}longhorn-0.1.0/lib/longhorn.rb:\d+!, out)
-    assert_match(%r!ruby/lib/set.rb!, out)
+    assert_match(%r!ruby/lib/\S*set.rb!, out)
   end
 
   def test_pretty
@@ -91,7 +91,7 @@ class TestCLI < Minitest::Test
 
     assert_match(/\d kB/, out)
     assert_match(%r!\d+\s{2}longhorn-0.1.0/lib/longhorn.rb:\d+!, out)
-    assert_match(%r!ruby/lib/set.rb!, out)
+    assert_match(%r!ruby/lib/\S*set.rb!, out)
   end
 
   def test_prints_help_when_script_not_specified

--- a/test/test_reporter.rb
+++ b/test/test_reporter.rb
@@ -12,7 +12,7 @@ class TestReporter < Minitest::Test
   def default_block
     # Create an object from a gem outside memory_profiler which allocates
     # its own objects internally
-    MiniTest::Reporter.new
+    Minitest::Reporter.new
 
     # Create 10 strings
     10.times { |i| i.to_s }
@@ -77,7 +77,7 @@ class TestReporter < Minitest::Test
 
   def test_counts
     results = create_report
-    assert_equal(16, results.total_allocated)
+    assert_equal(15, results.total_allocated)
     assert_equal(1, results.total_retained)
     assert_equal(1, results.retained_objects_by_location.length)
   end
@@ -96,13 +96,13 @@ class TestReporter < Minitest::Test
 
   def test_ignore_file_with_regex
     results = create_report(ignore_files: /test_reporter\.rb/)
-    assert_equal(3, results.total_allocated)
+    assert_equal(2, results.total_allocated)
     assert_equal(0, results.total_retained)
   end
 
   def test_ignore_file_with_string
     results = create_report(ignore_files: 'test_reporter.rb|another_file.rb')
-    assert_equal(3, results.total_allocated)
+    assert_equal(2, results.total_allocated)
     assert_equal(0, results.total_retained)
   end
 

--- a/test/test_reporter_public_start_stop.rb
+++ b/test/test_reporter_public_start_stop.rb
@@ -37,7 +37,7 @@ class TestReporterPublicStartStop < TestReporter
 
     assert_equal(reporter, same_reporter)
     # Some extra here due to variables needed in the test above
-    assert_equal(17, results.total_allocated)
+    assert_equal(16, results.total_allocated)
   end
 
   def test_exception_handling

--- a/test/test_results.rb
+++ b/test/test_results.rb
@@ -80,6 +80,6 @@ class TestResults < Minitest::Test
     io = StringIO.new
     report.pretty_print(io, normalize_paths: true)
     assert_match(%r!\d+\s{2}longhorn-0.1.0/lib/longhorn.rb:\d+!, io.string)
-    assert_match(%r!ruby/lib/set.rb!, io.string)
+    assert_match(%r!ruby/lib/\S*set.rb!, io.string)
   end
 end


### PR DESCRIPTION
Fixes #115.

Tests are currently failing (see https://github.com/SamSaffron/memory_profiler/pull/116, for example), suggesting that there are one less object allocated than we expect, because of some changes in minitest recently.

Previously, this line https://github.com/SamSaffron/memory_profiler/blob/cd6fa67ca785c4118110aac7a38654a257eb47b5/test/test_reporter.rb#L15 allocated 2 objects (array via `*args` and a `Thread::Mutex` instance): 
https://github.com/minitest/minitest/commit/5f5c2111f36658fd2636b108b8327ce4b2f3cf8d#diff-b43f1192f616004aa819abdb67ebe90528572c49ec805b9ad66ce45e1afce97bL622
https://github.com/ruby/mutex_m/blob/86ee14345740636a909b54f089f7eb0d51ea134f/lib/mutex_m.rb#L116-L119

But after the changes, only the mutex now: https://github.com/minitest/minitest/commit/5f5c2111f36658fd2636b108b8327ce4b2f3cf8d#diff-b43f1192f616004aa819abdb67ebe90528572c49ec805b9ad66ce45e1afce97bR621-R623