### PR TITLE
Drop `base64` dependency

### DIFF
--- a/lib/memory_profiler/autorun.rb
+++ b/lib/memory_profiler/autorun.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
 require "memory_profiler"
-require "base64"
 
 def deserialize_hash(data)
-  Marshal.load(Base64.urlsafe_decode64(data)) if data
+  Marshal.load(data.unpack1("m0")) if data
 end
 
 options = deserialize_hash(ENV["MEMORY_PROFILER_OPTIONS"]) || {}

--- a/lib/memory_profiler/cli.rb
+++ b/lib/memory_profiler/cli.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "optparse"
-require "base64"
 
 module MemoryProfiler
   class CLI
@@ -141,7 +140,7 @@ module MemoryProfiler
     end
 
     def serialize_hash(hash)
-      Base64.urlsafe_encode64(Marshal.dump(hash))
+      [Marshal.dump(hash)].pack("m0")
     end
   end
 end


### PR DESCRIPTION
Added in https://github.com/SamSaffron/memory_profiler/pull/116. On Ruby 3.4 this isn't a default gem anymore and will lead to errors when trying to require it. There are slightly more unintuitive "aliases" in the `pack`/`unpack` methods.

I don't believe the url escaping is actually needed. All it does is replace `+` with `-` and `/` with `_`.

cc @fatkodima 