### PR TITLE
Remove EOL Rubies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     name: Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3"]
+        ruby: ["3.1", "3.2", "3.3"]
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Remove EOL Rubies: < 3.1 are no longer supported (use an earlier version of the gem if needed)
+
 ## 1.0.2 - 17-06-2024
 
 - Add ability to profile commands via CLI @fatkodima

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A memory profiler for Ruby
 
 ## Requirements
 
-Ruby(MRI) Version 2.5.0 and above.
+Ruby(MRI) Version 3.1.0 and above.
 
 ## Installation
 

--- a/lib/memory_profiler/helpers.rb
+++ b/lib/memory_profiler/helpers.rb
@@ -6,7 +6,6 @@ module MemoryProfiler
     def initialize
       @gem_guess_cache = Hash.new
       @location_cache = Hash.new { |h, k| h[k] = Hash.new.compare_by_identity }
-      @class_name_cache = Hash.new.compare_by_identity
       @string_cache = Hash.new
     end
 
@@ -30,34 +29,17 @@ module MemoryProfiler
     end
 
     KERNEL_CLASS_METHOD = Kernel.instance_method(:class)
-    if UnboundMethod.method_defined?(:bind_call)
-      def object_class(obj)
-        klass = obj.class rescue nil
-        unless Class === klass
-          # attempt to determine the true Class when .class returns something other than a Class
-          klass = KERNEL_CLASS_METHOD.bind_call(obj)
-        end
-        klass
+    def object_class(obj)
+      klass = obj.class rescue nil
+      unless Class === klass
+        # attempt to determine the true Class when .class returns something other than a Class
+        klass = KERNEL_CLASS_METHOD.bind_call(obj)
       end
-    else
-      def object_class(obj)
-        klass = obj.class rescue nil
-        unless Class === klass
-          # attempt to determine the true Class when .class returns something other than a Class
-          klass = KERNEL_CLASS_METHOD.bind(obj).call
-        end
-        klass
-      end
+      klass
     end
 
-    if Object.name.frozen? # Since Ruby 2.7 Module#name no longer allocate a new string
-      def lookup_class_name(klass)
-        ((klass.is_a?(Class) && klass.name) || '<<Unknown>>').to_s
-      end
-    else
-      def lookup_class_name(klass)
-        @class_name_cache[klass] ||= ((klass.is_a?(Class) && klass.name) || '<<Unknown>>').to_s
-      end
+    def lookup_class_name(klass)
+      ((klass.is_a?(Class) && klass.name) || '<<Unknown>>').to_s
     end
 
     def lookup_string(obj)

--- a/memory_profiler.gemspec
+++ b/memory_profiler.gemspec
@@ -10,13 +10,13 @@ Gem::Specification.new do |spec|
   spec.version       = MemoryProfiler::VERSION
   spec.authors       = ["Sam Saffron"]
   spec.email         = ["sam.saffron@gmail.com"]
-  spec.description   = %q{Memory profiling routines for Ruby 2.5+}
-  spec.summary       = %q{Memory profiling routines for Ruby 2.5+}
+  spec.description   = %q{Memory profiling routines for Ruby 3.1+}
+  spec.summary       = %q{Memory profiling routines for Ruby 3.1+}
   spec.homepage      = "https://github.com/SamSaffron/memory_profiler"
   spec.license       = "MIT"
 
   spec.executables   = ["ruby-memory-profiler"]
   spec.files         = Dir["README.md", "CHANGELOG.md", "LICENSE.txt", "lib/**/*", "bin/ruby-memory-profiler"]
 
-  spec.required_ruby_version = ">= 2.5.0"
+  spec.required_ruby_version = ">= 3.1.0"
 end

--- a/test/test_reporter.rb
+++ b/test/test_reporter.rb
@@ -232,15 +232,7 @@ class TestReporter < Minitest::Test
       end
     end
 
-    if RUBY_VERSION < '3'
-      # 3 times "0", 2 times for interpolated strings
-      total_allocated = 5 * (3 + 2 + 2 + 2)
-      unique = 20
-    elsif RUBY_VERSION < '3.1'
-      # 3 times "0", 2 times for short interpolated strings, 3 times for long interpolated strings
-      total_allocated = 5 * (3 + 2 + 3 + 3)
-      unique = 20
-    elsif RUBY_VERSION < '3.3'
+    if RUBY_VERSION < '3.3'
       # 2 times for short interpolated strings, 3 times for long interpolated strings
       total_allocated = 5 * (2 + 3 + 3)
       unique = 15
@@ -262,7 +254,7 @@ class TestReporter < Minitest::Test
       string.to_sym
     end
 
-    strings_allocated = RUBY_VERSION < '3' ? 2 : 1
+    strings_allocated = 1
     assert_equal(strings_allocated + 1, results.total_allocated)
     assert_includes(0..1, results.total_retained)
     assert_equal(1, results.strings_allocated.size)


### PR DESCRIPTION
Drops support for EOL rubies (< 3.1). Follow up to https://github.com/SamSaffron/memory_profiler/pull/119#issuecomment-2174604707

I see that a project also has a `.rubocop.yml` defined, but the rubocop is not used. Let me know if you are interested in addition of it. I saw quite a few places where at least `rubocop-performance` can help reducing allocations. 