### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/memory_profiler

### DIFF
--- a/memory_profiler.gemspec
+++ b/memory_profiler.gemspec
@@ -19,4 +19,6 @@ Gem::Specification.new do |spec|
   spec.files         = Dir["README.md", "CHANGELOG.md", "LICENSE.txt", "lib/**/*", "bin/ruby-memory-profiler"]
 
   spec.required_ruby_version = ">= 3.1.0"
+
+  spec.metadata["changelog_uri"] = spec.homepage + "/blob/master/CHANGELOG.md'
 end


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/memory_profiler which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/