### PR TITLE
Fix tests for ruby 4+ by replacing set.rb with erb.rb in tests after Set moved to C

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     name: Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
-        ruby: ["3.1", "3.2", "3.3"]
+        ruby: ["3.1", "3.2", "3.3", "3.4", "4.0"]
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1

--- a/test/fixtures/gems/longhorn-0.1.0/lib/longhorn.rb
+++ b/test/fixtures/gems/longhorn-0.1.0/lib/longhorn.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
-require 'set'
+require 'erb'
 
 module Longhorn
   def self.run
-    result = Set.new
+    result = []
     ["allocated", "retained"]
       .product(["memory", "objects"])
       .product(["gem", "file", "location", "class"])
       .each do |(type, metric), name|
-        result << "#{type} #{metric} by #{name}"
+        result << ERB.new("<%= type %> <%= metric %> by <%= name %>").result(binding)
       end
     result
   end

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -21,21 +21,21 @@ class TestCLI < Minitest::Test
     out, _err = capture_io do
       @cli.run([@script_file])
     end
-    assert_includes out, "set.rb"
+    assert_includes out, STDLIB_FILE
 
     out, _err = capture_io do
-      @cli.run(["--ignore-files=set.rb", @script_file])
+      @cli.run(["--ignore-files=#{STDLIB_FILE}", @script_file])
     end
-    refute_includes out, "set.rb"
+    refute_includes out, STDLIB_FILE
   end
 
   def test_allow_specific_files
-    assert_output(/set\.rb/) { @cli.run([@script_file]) }
+    assert_output(/#{Regexp.escape(STDLIB_FILE)}/) { @cli.run([@script_file]) }
 
     out, _err = capture_io do
       @cli.run(["--allow-files=longhorn", @script_file])
     end
-    refute_includes out, "set.rb"
+    refute_includes out, STDLIB_FILE
   end
 
   def test_redirects_output_to_specific_file
@@ -81,7 +81,7 @@ class TestCLI < Minitest::Test
     end
 
     assert_match(%r!\d+\s{2}longhorn-0.1.0/lib/longhorn.rb:\d+!, out)
-    assert_match(%r!ruby/lib/\S*set.rb!, out)
+    assert_match(%r!ruby/lib/\S*#{Regexp.escape(STDLIB_FILE)}!, out)
   end
 
   def test_pretty
@@ -91,7 +91,7 @@ class TestCLI < Minitest::Test
 
     assert_match(/\d kB/, out)
     assert_match(%r!\d+\s{2}longhorn-0.1.0/lib/longhorn.rb:\d+!, out)
-    assert_match(%r!ruby/lib/\S*set.rb!, out)
+    assert_match(%r!ruby/lib/\S*#{Regexp.escape(STDLIB_FILE)}!, out)
   end
 
   def test_prints_help_when_script_not_specified

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,6 +7,12 @@ require_relative 'test_helpers'
 
 FIXTURE_DIR = File.expand_path('fixtures', __dir__).freeze
 
+# The stdlib .rb file required by the longhorn test fixture gem.
+# Used in assertions that check profiler output references a stdlib file.
+# If Ruby moves this to C (like it did with set.rb), change the fixture's
+# require and update this constant to another pure-Ruby stdlib file.
+STDLIB_FILE = "erb.rb".freeze
+
 def require_fixture_gem(name)
   lib_path = File.join(FIXTURE_DIR, 'gems', "#{name}-0.1.0", 'lib')
   $LOAD_PATH.unshift(lib_path) unless $LOAD_PATH.include?(lib_path)

--- a/test/test_results.rb
+++ b/test/test_results.rb
@@ -80,6 +80,6 @@ class TestResults < Minitest::Test
     io = StringIO.new
     report.pretty_print(io, normalize_paths: true)
     assert_match(%r!\d+\s{2}longhorn-0.1.0/lib/longhorn.rb:\d+!, io.string)
-    assert_match(%r!ruby/lib/\S*set.rb!, io.string)
+    assert_match(%r!ruby/lib/\S*#{Regexp.escape(STDLIB_FILE)}!, io.string)
   end
 end


### PR DESCRIPTION
Ruby moved Set to a C-based implementation, so set.rb no longer exists as a stdlib file. This broke tests that expected to see set.rb in profiler output.

- Changed longhorn test fixture to require 'erb' instead of 'set'
- Added STDLIB_FILE constant in test_helper.rb so the stdlib filename is defined in one place, making future changes easier
- Updated all test assertions to reference STDLIB_FILE